### PR TITLE
fix: #110 package.patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ See [example folder](example) for a minimal example.
 
 ### Including extra files
 
-All files from `package/patterns` will be included in the final build file. See [Patterns](https://serverless.com/framework/docs/providers/aws/guide/packaging#patterns)
+All files from `package/patterns` will be included in the final build file. See [Patterns](https://serverless.com/framework/docs/providers/aws/guide/packaging#patterns).
+
+Include/exclude is deprecated, but still supported.
 
 ### External Dependencies
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [example folder](example) for a minimal example.
 
 ### Including extra files
 
-All files from `package/include` will be included in the final build file. See [Exclude/Include](https://serverless.com/framework/docs/providers/aws/guide/packaging#exclude--include)
+All files from `package/patterns` will be included in the final build file. See [Patterns](https://serverless.com/framework/docs/providers/aws/guide/packaging#patterns)
 
 ### External Dependencies
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/jest": "^26.0.14",
     "@types/node": "^12.12.38",
     "@types/ramda": "^0.27.6",
-    "@types/serverless": "^1.78.18",
+    "@types/serverless": "^1.78.25",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "eslint": "^7.9.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,6 @@ export class EsbuildPlugin implements Plugin {
       const fn = this.serverless.service.getFunction(fnName);
       fn.package = fn.package || {
         patterns: [],
-        exclude: [],
       };
 
       // Add plugin to excluded packages or an empty array if exclude is undefined
@@ -244,13 +243,10 @@ export class EsbuildPlugin implements Plugin {
     // include any "extras" from the individual function "patterns" section
     for (const fnName in this.functions) {
       const fn = this.serverless.service.getFunction(fnName);
-      const fnPatterns = [
-        ...new Set([ ...(fn.package.include || []), ...(fn.package.patterns || []) ]),
-      ];
-      if (fnPatterns.length === 0) {
+      if (fn.package.patterns.length === 0) {
         continue;
       }
-      const files = await globby(fnPatterns);
+      const files = await globby(fn.package.patterns);
       for (const filename of files) {
         const destFileName = path.resolve(path.join(this.buildDirPath, `__only_${fn.name}`, filename));
         const dirname = path.dirname(destFileName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,13 +172,12 @@ export class EsbuildPlugin implements Plugin {
     for (const fnName in this.functions) {
       const fn = this.serverless.service.getFunction(fnName);
       fn.package = fn.package || {
-        exclude: [],
-        include: [],
+        patterns: [],
       };
 
       // Add plugin to excluded packages or an empty array if exclude is undefined
-      fn.package.exclude = [
-        ...new Set([...(fn.package.exclude || []), 'node_modules/serverless-esbuild']),
+      fn.package.patterns = [
+        ...new Set([ ...(fn.package.patterns || []), '!node_modules/serverless-esbuild' ]),
       ];
     }
   }
@@ -216,13 +215,13 @@ export class EsbuildPlugin implements Plugin {
     });
   }
 
-  /** Link or copy extras such as node_modules or package.include definitions */
+  /** Link or copy extras such as node_modules or package.patterns definitions */
   async copyExtras() {
     const { service } = this.serverless;
 
-    // include any "extras" from the "include" section
-    if (service.package.include && service.package.include.length > 0) {
-      const files = await globby(service.package.include);
+    // include any "extras" from the "patterns" section
+    if (service.package.patterns && service.package.patterns.length > 0) {
+      const files = await globby(service.package.patterns);
 
       for (const filename of files) {
         const destFileName = path.resolve(path.join(this.buildDirPath, filename));
@@ -233,7 +232,28 @@ export class EsbuildPlugin implements Plugin {
         }
 
         if (!fs.existsSync(destFileName)) {
-          fs.copySync(path.resolve(filename), path.resolve(path.join(this.buildDirPath, filename)));
+          fs.copySync(path.resolve(filename), destFileName);
+        }
+      }
+    }
+
+    // include any "extras" from the individual function "patterns" section
+    for (const fnName in this.functions) {
+      const fn = this.serverless.service.getFunction(fnName);
+      if (!fn.package?.patterns?.length) {
+        continue;
+      }
+      const files = await globby(fn.package.patterns);
+      for (const filename of files) {
+        const destFileName = path.resolve(path.join(this.buildDirPath, `__only_${fn.name}`, filename));
+        const dirname = path.dirname(destFileName);
+
+        if (!fs.existsSync(dirname)) {
+          fs.mkdirpSync(dirname);
+        }
+
+        if (!fs.existsSync(destFileName)) {
+          fs.copySync(path.resolve(filename), destFileName);
         }
       }
     }

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
 import * as path from 'path';
-import { intersection, isEmpty, path as get, without } from 'ramda';
+import { intersection, isEmpty, lensProp, map, over, path as get, pipe, reject, replace, test, without } from 'ramda';
 import * as semver from 'semver';
 import { EsbuildPlugin, SERVERLESS_FOLDER } from '.';
 import { doSharePath, flatDep, getDepsFromBundle } from './helper';
 import * as Packagers from './packagers';
+import { IFiles } from './types';
 import { humanSize, zip } from './utils';
 
 function setFunctionArtifactPath(this: EsbuildPlugin, func, artifactPath) {
@@ -38,7 +39,7 @@ export async function pack(this: EsbuildPlugin) {
     );
 
   // get a list of all path in build
-  const files: { localPath: string; rootPath: string }[] = glob
+  const files: IFiles = glob
     .sync('**', {
       cwd: this.buildDirPath,
       dot: true,
@@ -57,8 +58,14 @@ export async function pack(this: EsbuildPlugin) {
     const zipName = `${this.serverless.service.service}.zip`;
     const artifactPath = path.join(this.workDirPath, SERVERLESS_FOLDER, zipName);
 
+    // remove prefixes from individual extra files
+    const filesPathList = pipe<IFiles, IFiles, IFiles>(
+      reject(test(/^__only_[^/]+$/)) as (x: IFiles) => IFiles,
+      map(over(lensProp('localPath'), replace(/^__only_[^/]+\//, '')))
+    )(files);
+
     const startZip = Date.now();
-    await zip(artifactPath, files);
+    await zip(artifactPath, filesPathList);
     const { size } = fs.statSync(artifactPath);
 
     this.serverless.cli.log(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,2 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type JSONObject = any;
+
+export interface IFile {
+  readonly localPath: string
+  readonly rootPath: string
+}
+export type IFiles = readonly IFile[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import * as childProcess from 'child_process';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { join } from 'ramda';
+import { IFiles } from './types';
 
 export class SpawnError extends Error {
   constructor(message: string, public stdout: string, public stderr: string) {
@@ -91,7 +92,7 @@ export const humanSize = (size: number) => {
   return `${sanitized} ${['B', 'KB', 'MB', 'GB', 'TB'][i]}`;
 };
 
-export const zip = (zipPath: string, filesPathList: { rootPath: string; localPath: string }[]) => {
+export const zip = (zipPath: string, filesPathList: IFiles) => {
   fs.mkdirpSync(path.dirname(zipPath));
 
   const zip = archiver.create('zip');


### PR DESCRIPTION
- Update to latest @types/serverless which supports package.patterns
- Updated README to mention patterns and updated link to serverless docs
- Uses package.patterns instead of patterns.include in the global package section
- Added support for package.patterns on individual functions. It does this by copying the individual files into a special folder in the build folder, which gets ignored by all other functions. Then that special folder prefix gets removed when the intended function is packaged.

I'm not sure it's the best way to solve but at least it's a way to solve it :)