### PR TITLE
feat(esbuild): support esbuild plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ custom:
     packagePath: absolute/path/to/package.json # optional - by default it looks for a package.json in the working directory
 ```
 
+### Usign esbuild plugins
+
+*Note that the plugins API is still experimental : see [the documentation page](https://esbuild.github.io/plugins/)*
+
+You can configure esbuild plugins by passing a plugins' configuration file:
+
+```yml
+custom:
+  esbuild:
+    plugins: plugins.js
+```
+
+The plugins' configuration file must be a javascript file exporting an array of plugins (see `examples/individually/plugins.js` for a dummy plugin example)
+
 ## Usage
 
 ### Automatic compilation

--- a/examples/individually/plugins.js
+++ b/examples/individually/plugins.js
@@ -1,0 +1,12 @@
+let envPlugin = {
+  name: 'log-lodash',
+  setup(build) {
+    // test interception : log all lodash inports
+    build.onResolve({ filter: /^lodash$/ }, args => {
+      console.log(args);
+    });
+  },
+};
+
+// default export should be an array of plugins
+module.exports = [envPlugin];

--- a/examples/individually/serverless.yml
+++ b/examples/individually/serverless.yml
@@ -13,6 +13,7 @@ provider:
 
 custom:
   esbuild:
+    plugins : ./plugins.js
     packager: yarn
     bundle: true
     minify: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,11 +26,12 @@ export interface WatchConfiguration {
   ignore?: string[] | string;
 }
 
-export interface Configuration extends Omit<BuildOptions, 'watch'> {
+export interface Configuration extends Omit<BuildOptions, 'watch' | 'plugins'> {
   packager: 'npm' | 'yarn';
   packagePath: string;
   exclude: string[];
   watch: WatchConfiguration;
+  plugins?: string;
 }
 
 const DEFAULT_BUILD_OPTIONS: Partial<Configuration> = {
@@ -196,6 +197,9 @@ export class EsbuildPlugin implements Plugin {
           outdir: path.join(this.buildDirPath, path.dirname(entry)),
           platform: 'node',
           incremental,
+          plugins:
+            this.buildOptions.plugins &&
+            require(path.join(this.serverless.config.servicePath, this.buildOptions.plugins)),
         };
 
         // esbuild v0.7.0 introduced config options validation, so I have to delete plugin specific options from esbuild config.
@@ -203,6 +207,7 @@ export class EsbuildPlugin implements Plugin {
         delete config['packager'];
         delete config['packagePath'];
         delete config['watch'];
+        delete config['pugins'];
 
         const result = await build(config);
 


### PR DESCRIPTION
This is a naive implementation, but that might be all we need here.

I used the `plugins` key to let users pass on a path to the plugin definition file. Should it be named `pluginsDefinitionFile` or something in this taste? I think "plugins" is enough - but can be changed.