### PR TITLE
fix(packaging): exclude optional peer dependencies

### DIFF
--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -116,11 +116,11 @@ function getProdModules(
 
         // find peer dependencies but remove optional ones and excluded ones
         const peerDependencies = modulePackage.peerDependencies as Record<string, string>;
-        const optionalPeerDependencies = Object.keys(
+        const optionnalPeerDependencies = Object.keys(
           pickBy((val, key) => !val.optionnal, modulePackage.peerDependenciesMeta || {})
         );
         const peerDependenciesWithoutOptionals = omit(
-          [...optionalPeerDependencies, ...this.buildOptions.exclude],
+          [...optionnalPeerDependencies, ...this.buildOptions.exclude],
           peerDependencies
         );
 

--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -116,11 +116,11 @@ function getProdModules(
 
         // find peer dependencies but remove optional ones and excluded ones
         const peerDependencies = modulePackage.peerDependencies as Record<string, string>;
-        const optionnalPeerDependencies = Object.keys(
-          pickBy((val, key) => !val.optionnal, modulePackage.peerDependenciesMeta || {})
+        const optionalPeerDependencies = Object.keys(
+          pickBy((val, key) => !val.optional, modulePackage.peerDependenciesMeta || {})
         );
         const peerDependenciesWithoutOptionals = omit(
-          [...optionnalPeerDependencies, ...this.buildOptions.exclude],
+          [...optionalPeerDependencies, ...this.buildOptions.exclude],
           peerDependencies
         );
 

--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -114,12 +114,15 @@ function getProdModules(
 
         const modulePackage = require(modulePackagePath);
 
-        // find peer dependencies but remove optional ones
+        // find peer dependencies but remove optional ones and excluded ones
         const peerDependencies = modulePackage.peerDependencies as Record<string, string>;
         const optionalPeerDependencies = Object.keys(
           pickBy((val, key) => !val.optionnal, modulePackage.peerDependenciesMeta || {})
         );
-        const peerDependenciesWithoutOptionals = omit(optionalPeerDependencies, peerDependencies);
+        const peerDependenciesWithoutOptionals = omit(
+          [...optionalPeerDependencies, ...this.buildOptions.exclude],
+          peerDependencies
+        );
 
         if (!isEmpty(peerDependenciesWithoutOptionals)) {
           this.options.verbose &&

--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -117,7 +117,7 @@ function getProdModules(
         // find peer dependencies but remove optional ones and excluded ones
         const peerDependencies = modulePackage.peerDependencies as Record<string, string>;
         const optionalPeerDependencies = Object.keys(
-          pickBy((val, key) => !val.optional, modulePackage.peerDependenciesMeta || {})
+          pickBy(val => val.optional, modulePackage.peerDependenciesMeta || {})
         );
         const peerDependenciesWithoutOptionals = omit(
           [...optionalPeerDependencies, ...this.buildOptions.exclude],

--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -11,8 +11,10 @@ import {
   keys,
   map,
   mergeRight,
+  omit,
   path as get,
   pick,
+  pickBy,
   replace,
   split,
   startsWith,
@@ -111,18 +113,25 @@ function getProdModules(
           : null;
 
         const modulePackage = require(modulePackagePath);
+
+        // find peer dependencies but remove optional ones
         const peerDependencies = modulePackage.peerDependencies as Record<string, string>;
-        if (!isEmpty(peerDependencies)) {
+        const optionalPeerDependencies = Object.keys(
+          pickBy((val, key) => !val.optionnal, modulePackage.peerDependenciesMeta || {})
+        );
+        const peerDependenciesWithoutOptionals = omit(optionalPeerDependencies, peerDependencies);
+
+        if (!isEmpty(peerDependenciesWithoutOptionals)) {
           this.options.verbose &&
             this.serverless.cli.log(
-              `Adding explicit peers for dependency ${externalModule.external}`
+              `Adding explicit non-optionals peers for dependency ${externalModule.external}`
             );
           const peerModules = getProdModules.call(
             this,
             compose(
               map(([external]) => ({ external })),
               toPairs
-            )(peerDependencies),
+            )(peerDependenciesWithoutOptionals),
             packageJsonPath,
             rootPackageJsonPath
           );

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -7,7 +7,6 @@ import {
   lensProp,
   map,
   over,
-  path as get,
   pipe,
   reject,
   replace,
@@ -18,6 +17,7 @@ import * as semver from 'semver';
 import { EsbuildPlugin, SERVERLESS_FOLDER } from '.';
 import { doSharePath, flatDep, getDepsFromBundle } from './helper';
 import * as Packagers from './packagers';
+import { get as getPackager } from './packagers';
 import { IFiles } from './types';
 import { humanSize, zip } from './utils';
 
@@ -101,8 +101,9 @@ export async function pack(this: EsbuildPlugin) {
   const hasExternals = !!externals?.length;
 
   // get a tree of all production dependencies
+  // get a tree of all production dependencies
   const packagerDependenciesList = hasExternals
-    ? await packager.getProdDependencies(this.buildDirPath)
+    ? await (await getPackager('npm')).getProdDependencies(this.buildDirPath)
     : {};
 
   // package each function

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -1,7 +1,19 @@
 import * as fs from 'fs-extra';
-import * as glob from 'glob';
+import * as globby from 'globby';
 import * as path from 'path';
-import { intersection, isEmpty, lensProp, map, over, path as get, pipe, reject, replace, test, without } from 'ramda';
+import {
+  intersection,
+  isEmpty,
+  lensProp,
+  map,
+  over,
+  path as get,
+  pipe,
+  reject,
+  replace,
+  test,
+  without,
+} from 'ramda';
 import * as semver from 'semver';
 import { EsbuildPlugin, SERVERLESS_FOLDER } from '.';
 import { doSharePath, flatDep, getDepsFromBundle } from './helper';
@@ -39,12 +51,11 @@ export async function pack(this: EsbuildPlugin) {
     );
 
   // get a list of all path in build
-  const files: IFiles = glob
+  const files: IFiles = globby
     .sync('**', {
       cwd: this.buildDirPath,
       dot: true,
-      silent: true,
-      follow: true,
+      onlyFiles: true,
     })
     .filter(p => !excludedFiles.includes(p))
     .map(localPath => ({ localPath, rootPath: path.join(this.buildDirPath, localPath) }));
@@ -114,28 +125,33 @@ export async function pack(this: EsbuildPlugin) {
       const artifactPath = path.join(this.workDirPath, SERVERLESS_FOLDER, zipName);
 
       // filter files
-      const filesPathList = files.filter(({ localPath }) => {
-        // exclude non individual files based on file path (and things that look derived, e.g. foo.js => foo.js.map)
-        if (excludedFiles.find(p => localPath.startsWith(p))) return false;
+      const filesPathList = files
+        .filter(({ localPath }) => {
+          // exclude non individual files based on file path (and things that look derived, e.g. foo.js => foo.js.map)
+          if (excludedFiles.find(p => localPath.startsWith(p))) return false;
 
-        // exclude files that belong to individual functions
-        if (localPath.startsWith('__only_') && !localPath.startsWith(`__only_${name}/`)) return false;
-
-        // exclude non whitelisted dependencies
-        if (localPath.startsWith('node_modules')) {
-          // if no externals is set or if the provider is google, we do not need any files from node_modules
-          if (!hasExternals || isGoogleProvider) return false;
-          if (
-            // this is needed for dependencies that maps to a path (like scoped ones)
-            !depWhiteList.find(dep => doSharePath(localPath, 'node_modules/' + dep))
-          )
+          // exclude files that belong to individual functions
+          if (localPath.startsWith('__only_') && !localPath.startsWith(`__only_${name}/`))
             return false;
-        }
 
-        return true;
-      })
-      // remove prefix from individual function extra files
-      .map(({localPath, ...rest}) => ({ localPath: localPath.replace(`__only_${name}/`, ''), ...rest}));
+          // exclude non whitelisted dependencies
+          if (localPath.startsWith('node_modules')) {
+            // if no externals is set or if the provider is google, we do not need any files from node_modules
+            if (!hasExternals || isGoogleProvider) return false;
+            if (
+              // this is needed for dependencies that maps to a path (like scoped ones)
+              !depWhiteList.find(dep => doSharePath(localPath, 'node_modules/' + dep))
+            )
+              return false;
+          }
+
+          return true;
+        })
+        // remove prefix from individual function extra files
+        .map(({ localPath, ...rest }) => ({
+          localPath: localPath.replace(`__only_${name}/`, ''),
+          ...rest,
+        }));
 
       const startZip = Date.now();
       await zip(artifactPath, filesPathList);

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -17,7 +17,6 @@ import * as semver from 'semver';
 import { EsbuildPlugin, SERVERLESS_FOLDER } from '.';
 import { doSharePath, flatDep, getDepsFromBundle } from './helper';
 import * as Packagers from './packagers';
-import { get as getPackager } from './packagers';
 import { IFiles } from './types';
 import { humanSize, zip } from './utils';
 
@@ -101,9 +100,8 @@ export async function pack(this: EsbuildPlugin) {
   const hasExternals = !!externals?.length;
 
   // get a tree of all production dependencies
-  // get a tree of all production dependencies
   const packagerDependenciesList = hasExternals
-    ? await (await getPackager('npm')).getProdDependencies(this.buildDirPath)
+    ? await packager.getProdDependencies(this.buildDirPath)
     : {};
 
   // package each function

--- a/src/packagers/yarn.ts
+++ b/src/packagers/yarn.ts
@@ -83,7 +83,7 @@ export class Yarn implements Packager {
           return __;
         },
         {},
-        convertingTrees
+        convertingTrees || []
       );
 
     const trees = pathOr([], ['data', 'trees'], parsedTree);


### PR DESCRIPTION
This excludes optional dependencies to be installed when resolving peer dependencies. 

It also replaces glob with globby in `pack.ts`, however, this does not change much anything as we still need to `stat` for the file mode. Globby can stat for us in one pass, but the types are not yet complete on their side. I took the lazy route here and just replaced glob. We can improve that later on.