### PR TITLE
feat(externals): add option to disable packing of external modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,17 @@ custom:
     packagePath: absolute/path/to/package.json # optional - by default it looks for a package.json in the working directory
 ```
 
+This behavior can be disabled via `packExternals`:
+
+```yml
+custom:
+  esbuild:
+    packExternals: false
+```
+
 ### Usign esbuild plugins
 
-*Note that the plugins API is still experimental : see [the documentation page](https://esbuild.github.io/plugins/)*
+_Note that the plugins API is still experimental : see [the documentation page](https://esbuild.github.io/plugins/)_
 
 You can configure esbuild plugins by passing a plugins' configuration file:
 

--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -190,7 +190,7 @@ function getProdModules(
 export async function packExternalModules(this: EsbuildPlugin) {
   const externals = without(this.buildOptions.exclude, this.buildOptions.external);
 
-  if (!externals || !externals.length) {
+  if (!externals || !externals.length || !this.buildOptions.packExternals) {
     return;
   }
 
@@ -294,7 +294,6 @@ export async function packExternalModules(this: EsbuildPlugin) {
   this.serverless.cli.log('Packing external modules: ' + compositeModules.join(', '));
   await packager.install(compositeModulePath, exists);
   this.options.verbose && this.serverless.cli.log(`Package took [${Date.now() - start} ms]`);
-
   // Prune extraneous packages - removes not needed ones
   const startPrune = Date.now();
   await packager.prune(compositeModulePath);


### PR DESCRIPTION
Adds an additional configuration option `packExternals` which will disable installing & bundling modules listed as external.

This is useful for if you want to exclude externals from esbuild but you don't need them installed & packed separately. My use-case was with serverless-offline as externals can be imported normally from node_modules, leading to a faster build. Another use-case could be if you're using lambda layers.