### PR TITLE
fix(pack): servicePath not set for invoke local

### DIFF
--- a/src/pre-local.ts
+++ b/src/pre-local.ts
@@ -1,6 +1,7 @@
 import { EsbuildPlugin } from '.';
 export function preLocal(this: EsbuildPlugin) {
   this.serviceDirPath = this.buildDirPath;
+  this.serverless.config.servicePath = this.buildDirPath;
   // Set service path as CWD to allow accessing bundled files correctly
   process.chdir(this.serviceDirPath);
 }


### PR DESCRIPTION
I debugged the problem #120 and found that the function [invokeLocalNodeJS](https://github.com/serverless/serverless/blob/6d2ed840fb21d469d8e4a548a38ca9302d5a9d2c/lib/plugins/aws/invokeLocal/index.js#L745) will use `this.serverless.serviceDir` to set the path to the transpiled handler entry file.

I also compared this with [serverless-webpack](https://github.com/serverless-heaven/serverless-webpack/blob/a2de4d8a93c448a45e501f846f9232d774589578/lib/prepareLocalInvoke.js#L20) and they handle this similar.

@floydspace can you check if I missed to set this correctly when `service.package.individually` is set to `true`.
