### PR TITLE
Check for existing results to rebuild

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -229,9 +229,9 @@ export class EsbuildPlugin implements Plugin {
         const bundlePath = entry.substr(0, entry.lastIndexOf('.')) + '.js';
 
         if (this.buildResults) {
-          const { result: oldResult } = this.buildResults.find(({func: fn}) => fn.name === func.name);
-          await oldResult.rebuild();
-          return { result: oldResult, bundlePath, func };
+          const { result } = this.buildResults.find(({func: fn}) => fn.name === func.name);
+          await result.rebuild();
+          return { result, bundlePath, func };
         }
 
         const result = await build(config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,7 @@ export class EsbuildPlugin implements Plugin {
     }
   }
 
-  async bundle(incremental = false): Promise<BuildResult[]> {
+  async bundle(incremental = true): Promise<BuildResult[]> {
     this.prepare();
     this.serverless.cli.log('Compiling with esbuild...');
 
@@ -226,9 +226,16 @@ export class EsbuildPlugin implements Plugin {
         delete config['watch'];
         delete config['pugins'];
 
+        const bundlePath = entry.substr(0, entry.lastIndexOf('.')) + '.js';
+
+        if (this.buildResults) {
+          const { result: oldResult } = this.buildResults.find(({func: fn}) => fn.name === func.name);
+          await oldResult.rebuild();
+          return { result: oldResult, bundlePath, func };
+        }
+
         const result = await build(config);
 
-        const bundlePath = entry.substr(0, entry.lastIndexOf('.')) + '.js';
         return { result, bundlePath, func };
       })
     ).then(results => {


### PR DESCRIPTION
Currently, this plugin calls the ESBuild `build` method each time a file is changed.

As documented in #98, this behavior results in exponentially increasing memory usage as files are changed. Personally, I saw my memory usage (from the esbuild process) spike from an initial value of 600 MB to 2GB after just 5 changes. Ultimately, the memory usage results in a fatal error, where the JavaScript heap runs out of memory. 

## What I did

In this pull request, I've added a conditional check in the `bundle` method to call `rebuild` instead of `build` if there are existing build results.

I also set the `bundle` method to enable incremental builds by default. From what I understand, the way the ESBuild process works is as documented [here](https://esbuild.github.io/api/#incremental):

1. Create an initial build with `incremental: true`.
2. Rebuild as necessary by calling `rebuild` on the existing build result.

## Results

With the change in this PR, memory usage increases much more slowly. After about 10 file changes, the memory only increased to about 1GB (I noticed a linear increase of about 30MB each time). Further debugging is needed to determine the source of that slight memory usage increase, but it seems like this optimization addresses the majority of the existing increases in memory usage. 