### PR TITLE
fix(build): disabling incremental build outside of offline use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,14 +91,14 @@ export class EsbuildPlugin implements Plugin {
         await this.copyExtras();
       },
       'before:offline:start': async () => {
-        await this.bundle();
+        await this.bundle(true);
         await this.packExternalModules();
         await this.copyExtras();
         await this.preOffline();
         this.watch();
       },
       'before:offline:start:init': async () => {
-        await this.bundle();
+        await this.bundle(true);
         await this.packExternalModules();
         await this.copyExtras();
         await this.preOffline();
@@ -201,7 +201,7 @@ export class EsbuildPlugin implements Plugin {
     }
   }
 
-  async bundle(incremental = true): Promise<BuildResult[]> {
+  async bundle(incremental = false): Promise<BuildResult[]> {
     this.prepare();
     this.serverless.cli.log('Compiling with esbuild...');
 
@@ -229,7 +229,7 @@ export class EsbuildPlugin implements Plugin {
         const bundlePath = entry.substr(0, entry.lastIndexOf('.')) + '.js';
 
         if (this.buildResults) {
-          const { result } = this.buildResults.find(({func: fn}) => fn.name === func.name);
+          const { result } = this.buildResults.find(({ func: fn }) => fn.name === func.name);
           await result.rebuild();
           return { result, bundlePath, func };
         }


### PR DESCRIPTION
This PR addresses the bug introduced in #123 where the esbuild process doe not close after packaging, deploy or local invoke.
The proposal is to only use incremental builds with offline mode, which makes sense.
It should then fix #124