### PR TITLE
feat: write metafile when the metafile option is set to true

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -237,6 +237,10 @@ export class EsbuildPlugin implements Plugin {
 
         const result = await build(config);
 
+        if (config.metafile) {
+          fs.writeFileSync(`${WORK_FOLDER}/meta-${func.name}.json`, JSON.stringify(result.metafile));
+        }
+
         return { result, bundlePath, func, functionAlias };
       })
     ).then(results => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { packExternalModules } from './pack-externals';
 import { pack } from './pack';
 import { preOffline } from './pre-offline';
 import { preLocal } from './pre-local';
+import { trimExtension } from './utils';
 
 export const SERVERLESS_FOLDER = '.serverless';
 export const BUILD_FOLDER = '.build';
@@ -238,7 +239,7 @@ export class EsbuildPlugin implements Plugin {
         const result = await build(config);
 
         if (config.metafile) {
-          fs.writeFileSync(`${WORK_FOLDER}/meta-${func.name}.json`, JSON.stringify(result.metafile));
+          fs.writeFileSync(path.join(this.buildDirPath, `${trimExtension(entry)}-meta.json`), JSON.stringify(result.metafile, null, 2));
         }
 
         return { result, bundlePath, func, functionAlias };

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -18,7 +18,7 @@ import { EsbuildPlugin, SERVERLESS_FOLDER } from '.';
 import { doSharePath, flatDep, getDepsFromBundle } from './helper';
 import * as Packagers from './packagers';
 import { IFiles } from './types';
-import { humanSize, zip } from './utils';
+import { humanSize, zip, trimExtension } from './utils';
 
 function setFunctionArtifactPath(this: EsbuildPlugin, func, artifactPath) {
   const version = this.serverless.getVersion();
@@ -109,7 +109,7 @@ export async function pack(this: EsbuildPlugin) {
     buildResults.map(async ({ func, functionAlias, bundlePath }) => {
       const name = `${this.serverless.service.getServiceName()}-${this.serverless.service.provider.stage}-${functionAlias}`;
 
-      const excludedFiles = bundlePathList.filter(p => !bundlePath.startsWith(p));
+      const excludedFiles = bundlePathList.filter(p => !bundlePath.startsWith(p)).map(trimExtension);
 
       // allowed external dependencies in the final zip
       let depWhiteList = [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,3 +123,7 @@ export const zip = (zipPath: string, filesPathList: IFiles) => {
     zip.on('error', err => reject(err));
   });
 };
+
+export function trimExtension(entry: string) {
+  return entry.slice(0, -path.extname(entry).length);
+}


### PR DESCRIPTION
Hello and thanks for this awesome plugin !

When debugging a performance issue on some of my lambdas, I found that it was not possible to output the meta files and therefore the debugging was a bit painful.

This is due to a specific implementation of the esbuild metafile option, that returns the meta in the result object of the build, but delegates the handling of it to its caller : https://esbuild.github.io/api/#metafile

Closes: https://github.com/floydspace/serverless-esbuild/issues/121