### PR TITLE
Fix bad example link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ custom:
 Check [esbuild](https://github.com/evanw/esbuild#command-line-usage) documentation for the full list of available options. Note that some options like `entryPoints` or `outdir` cannot be overwritten.
 The package specified in the `exclude` option is passed to esbuild as `external`, but it is not included in the function bundle either. The default value for this option is `['aws-sdk']`.
 
-See [example folder](example) for a minimal example.
+See [example folder](examples) for a minimal example.
 
 ### Including extra files
 


### PR DESCRIPTION
Currently if you click the `See example folder for a minimal example.` link in the README.md it takes you to https://github.com/floydspace/serverless-esbuild/blob/master/example (singular), which is not a valid url.

Instead it should take you to https://github.com/floydspace/serverless-esbuild/blob/master/examples (plural)