### PR TITLE
Feature/ignore non node functions

### DIFF
--- a/src/pack.ts
+++ b/src/pack.ts
@@ -60,7 +60,8 @@ export async function pack(this: EsbuildPlugin) {
     .map(localPath => ({ localPath, rootPath: path.join(this.buildDirPath, localPath) }));
 
   if (isEmpty(files)) {
-    throw new Error('Packaging: No files found');
+    console.log(`Packaging: No files found. Skipping esbuild.`);
+    return;
   }
 
   // 1) If individually is not set, just zip the all build dir and return


### PR DESCRIPTION
Checking for non node functions and ignoring them, in case we have multiple runtimes per stack, like python.
Also, the plugin doesn't fail anymore if no node function was found, since we can manually deploy non node functions.