### PR TITLE
fix(pack): function files with names whose prefix is same as other function names

### DIFF
--- a/src/pack.ts
+++ b/src/pack.ts
@@ -127,7 +127,7 @@ export async function pack(this: EsbuildPlugin) {
       const filesPathList = files
         .filter(({ localPath }) => {
           // exclude non individual files based on file path (and things that look derived, e.g. foo.js => foo.js.map)
-          if (excludedFiles.find(p => localPath.startsWith(p))) return false;
+          if (excludedFiles.find(p => localPath.startsWith(`${p}.`))) return false;
 
           // exclude files that belong to individual functions
           if (localPath.startsWith('__only_') && !localPath.startsWith(`__only_${name}/`))


### PR DESCRIPTION
This is a fix.

When functions have names with prefix which is same as any other function name, their bundled js files are being excluded in the final artefact.

Ex: For an application having two functions with names `function-name` and `function-name-other`. The packaging (individually) is excluding the bundled `js` & `js.map` files for `function-name-other` in the final artefact.