### PR TITLE
fix: resolve working dir issue with zipping code when not packaging i…

### DIFF
--- a/src/pack.ts
+++ b/src/pack.ts
@@ -75,7 +75,7 @@ export async function pack(this: EsbuildPlugin) {
     )(files);
 
     const startZip = Date.now();
-    await zip(artifactPath, filesPathList);
+    await zip(artifactPath, filesPathList, this.buildDirPath);
     const { size } = fs.statSync(artifactPath);
 
     this.serverless.cli.log(


### PR DESCRIPTION
…ndividually

Hi, just having some issues locally with v1.14.0 where :
```
package:
  individually: false
```
causes the esbuild output to get written out successfully but then fails to zip with an error like
```
Serverless: Compiling to node12.22.1 bundle with esbuild...
Serverless: Compiling completed.
 
 Error ---------------------------------------------------

  Error: ENOENT: no such file or directory, stat 'c:\myrepopath\myreponame\src\functions\myfunctionname.js'

     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com

  Your Environment Information ---------------------------
     Operating System:          win32
     Node Version:              15.5.0
     Framework Version:         2.48.0 (local)
     Plugin Version:            5.4.2
     SDK Version:               4.2.3
     Components Version:        3.12.0
```
This change seems to fix it for me locally. Feel free to reject if it doesn't work for other use cases!