### PR TITLE
Fix zip() usage in non-individually packaging mode

### DIFF
--- a/src/pack.ts
+++ b/src/pack.ts
@@ -75,7 +75,7 @@ export async function pack(this: EsbuildPlugin) {
     )(files);
 
     const startZip = Date.now();
-    await zip(artifactPath, filesPathList);
+    await zip(artifactPath, filesPathList, this.buildDirPath);
     const { size } = fs.statSync(artifactPath);
 
     this.serverless.cli.log(


### PR DESCRIPTION
This PR fixes a small bug introduced in PR #148 which fixed #96.

#148 updated one call site for `zip()` but the other call site, which handles the non-individually packaging mode, was not updated.

Without this patch, the `pack` step fails with the following error when your `serverless.yml` does not use the `package: individually` option:

```
zip error: Nothing to do! (try: zip --quiet --recurse-paths ${HOME}/myproject/.esbuild/.serverless/my-api.zip . -i src/publicApiHandler.js)
```