### PR TITLE
fix(esbuild): include plugins config for esbuild

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -237,7 +237,6 @@ export class EsbuildPlugin implements Plugin {
         delete config['packager'];
         delete config['packagePath'];
         delete config['watch'];
-        delete config['plugins'];
         delete config['keepOutputDirectory'];
 
         const bundlePath = entry.substr(0, entry.lastIndexOf('.')) + '.js';


### PR DESCRIPTION
Esbuild needs plugins config to load the plugins. Since `plugins` is an expected BuildOption, I think it is safe to retain it.

``` ts
export interface BuildOptions extends CommonOptions {
  bundle?: boolean;
  splitting?: boolean;
  preserveSymlinks?: boolean;
  outfile?: string;
  metafile?: boolean;
  outdir?: string;
  outbase?: string;
  platform?: Platform;
  external?: string[];
  loader?: { [ext: string]: Loader };
  resolveExtensions?: string[];
  mainFields?: string[];
  conditions?: string[];
  write?: boolean;
  allowOverwrite?: boolean;
  tsconfig?: string;
  outExtension?: { [ext: string]: string };
  publicPath?: string;
  entryNames?: string;
  chunkNames?: string;
  assetNames?: string;
  inject?: string[];
  banner?: { [type: string]: string };
  footer?: { [type: string]: string };
  incremental?: boolean;
  entryPoints?: string[] | Record<string, string>;
  stdin?: StdinOptions;
  plugins?: Plugin[];
  absWorkingDir?: string;
  nodePaths?: string[]; // The "NODE_PATH" variable from Node.js
  watch?: boolean | WatchMode;
}

```

PS: I have found that the plugins are not being loaded after the `1.15.0` release. With the `esbuild-node-externals` plugin, I don't see the `node_modules` being packaged w/ `1.15.0`, since the plugins config is not being passed on?. The issue can be reproduced with https://github.com/vamche/sls-esbuild-node-externals/tree/missing-node-modules-with-node-externals-plugin (branch: `missing-node-modules-with-node-externals-plugin`)
