### PR TITLE
feat(packager): ability to run custom scripts after packager install

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ custom:
   esbuild:
     packager: yarn # optional - npm or yarn, default is npm
     packagePath: absolute/path/to/package.json # optional - by default it looks for a package.json in the working directory
+    packagerOptions: # optional - packager related options, currently supports only 'scripts' for both npm and yarn
+      scripts: # scripts to be executed, can be a string or array of strings
+        - echo 'Hello World!'
+        - rm -rf node_modules
 ```
 
 To easily mark all the `dependencies` in `package.json` as `external`, you can utilize `esbuild-node-externals` [plugin](https://www.npmjs.com/package/esbuild-node-externals).

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,10 @@ export interface WatchConfiguration {
   ignore?: string[] | string;
 }
 
+export interface PackagerOptions {
+  scripts?: string[] | string;
+}
+
 export interface Configuration extends Omit<BuildOptions, 'watch' | 'plugins'> {
   packager: 'npm' | 'yarn';
   packagePath: string;
@@ -34,6 +38,7 @@ export interface Configuration extends Omit<BuildOptions, 'watch' | 'plugins'> {
   watch: WatchConfiguration;
   plugins?: string;
   keepOutputDirectory?: boolean;
+  packagerOptions?: PackagerOptions;
 }
 
 const DEFAULT_BUILD_OPTIONS: Partial<Configuration> = {
@@ -46,7 +51,8 @@ const DEFAULT_BUILD_OPTIONS: Partial<Configuration> = {
     pattern: './**/*.(js|ts)',
     ignore: [WORK_FOLDER, 'dist', 'node_modules', SERVERLESS_FOLDER],
   },
-  keepOutputDirectory: false
+  keepOutputDirectory: false,
+  packagerOptions: {},
 };
 
 export class EsbuildPlugin implements Plugin {
@@ -238,6 +244,7 @@ export class EsbuildPlugin implements Plugin {
         delete config['packagePath'];
         delete config['watch'];
         delete config['keepOutputDirectory'];
+        delete config['packagerOptions'];
 
         const bundlePath = entry.substr(0, entry.lastIndexOf('.')) + '.js';
 


### PR DESCRIPTION
This gives the ability to run custom scripts after packager install.

Use cases: remove/clean-up node modules etc.,

I have tested this with both `yarn/npm`, also w/ packaging individually `true/false`

You can find the reference script here: 
https://github.com/vamche/sls-esbuild-node-externals/blob/7a88127993acda4b12867245e8ac023cc68a6e13/serverless.yml#L22-L25
