### PR TITLE
fix(package): fix wrong argument to get package's root

### DIFF
--- a/src/tests/util.test.ts
+++ b/src/tests/util.test.ts
@@ -2,11 +2,11 @@ import { findProjectRoot } from '../utils';
 import * as path from 'path';
 
 describe('utils/findProjectRoot', () => {
-    it('should properly Find a Project Root.', () => {
-        /* Broken implementation in pack-externals we're trying to fix. */
-        const rootPackageJsonPath = path.join(findProjectRoot(), './package.json');
+  it('should properly Find a Project Root.', () => {
+    /* Broken implementation in pack-externals we're trying to fix. */
+    const rootPackageJsonPath = path.join(findProjectRoot() || '', './package.json');
 
-        /* Looking up at project root relative to ./src/tests/ */
-        expect(rootPackageJsonPath).toEqual(path.join(__dirname, '../../package.json'));
-    });
+    /* Looking up at project root relative to ./src/tests/ */
+    expect(rootPackageJsonPath).toEqual(path.join(__dirname, '../../package.json'));
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,19 +64,20 @@ export function spawnProcess(
 /**
  * Find a file by walking up parent directories
  */
-export function findUp(name: string | string[], directory: string = process.cwd()): string | undefined {
+export function findUp(
+  names: string | string[],
+  directory: string = process.cwd()
+): string | undefined {
   const absoluteDirectory = path.resolve(directory);
 
-  if (typeof name === 'string') {
+  if (typeof names === 'string') {
+    names = [names];
+  }
+
+  /* For vs. .forEach so it can exit when we get a hit. */
+  for (const name of names) {
     if (fs.existsSync(path.join(directory, name))) {
       return directory;
-    }
-  } else {
-    /* For vs. .forEach so it can exit when we get a hit. */
-    for (let x = 0; x < name.length; x++) {
-      if (fs.existsSync(path.join(directory, name[x]))) {
-        return directory;
-      }
     }
   }
 
@@ -85,14 +86,14 @@ export function findUp(name: string | string[], directory: string = process.cwd(
     return undefined;
   }
 
-  return findUp(name, path.dirname(absoluteDirectory));
+  return findUp(names, path.dirname(absoluteDirectory));
 }
 
 /**
  * Forwards `rootDir` or finds project root folder.
  */
 export function findProjectRoot(rootDir?: string): string | undefined {
-  return rootDir ?? findUp(['yarn.lock', 'package-lock.json', 'package.json']);
+  return rootDir ?? findUp(['yarn.lock', 'package-lock.json']);
 }
 
 export const humanSize = (size: number) => {
@@ -107,7 +108,7 @@ export const zip = (zipPath: string, filesPathList: IFiles, workingDir?: string)
   return bestzip({
     source: filesPathList.map((file: IFile) => file.localPath),
     destination: zipPath,
-    cwd: workingDir || process.cwd()
+    cwd: workingDir || process.cwd(),
   });
 };
 


### PR DESCRIPTION
A problem arouse in one of my project : mongoose was required by a dependency with a specific version. We put mongoose as external because it relies on system code.
But as mongoose was not listed as dependency of our project, its version was not caught by the plugin ; as such a later, incompatible version of mongoose was packaged.
This PR changes the way we get the dep versions by checking the module package.json found either in node_modules or the root node_modules (in case of a workspaced project).
It also changes the arguments to get the project root (a package.json is always found even if it is not the root).