### PR TITLE
Always include files that are in patterns

### DIFF
--- a/src/pack.ts
+++ b/src/pack.ts
@@ -104,6 +104,10 @@ export async function pack(this: EsbuildServerlessPlugin) {
     ? await packager.getProdDependencies(this.buildDirPath)
     : {};
 
+  const packageFiles = await globby(
+    this.serverless.service.package.patterns
+  );
+
   // package each function
   await Promise.all(
     buildResults.map(async ({ func, functionAlias, bundlePath }) => {
@@ -112,8 +116,12 @@ export async function pack(this: EsbuildServerlessPlugin) {
       }-${functionAlias}`;
 
       const excludedFiles = bundlePathList
-        .filter((p) => !bundlePath.startsWith(p))
-        .map(trimExtension);
+      .filter((p) => !bundlePath.startsWith(p))
+      .map(trimExtension);
+
+      const functionFiles = await globby(func.package.patterns);
+
+      const includedFiles = [...packageFiles, ...functionFiles];
 
       // allowed external dependencies in the final zip
       let depWhiteList = [];
@@ -130,6 +138,11 @@ export async function pack(this: EsbuildServerlessPlugin) {
       // filter files
       const filesPathList = files
         .filter(({ localPath }) => {
+          // if file is present in patterns it must be included
+          if (includedFiles.find(file => file === localPath)) {
+            return true;
+          }
+
           // exclude non individual files based on file path (and things that look derived, e.g. foo.js => foo.js.map)
           if (excludedFiles.find((p) => localPath.startsWith(`${p}.`))) return false;
 


### PR DESCRIPTION
Before this change if a directory or file was in node_modules for
example the `.prisma` directory that gets created by prisma but not marked
as a dep or peer dep it would be removed.

Adding this directory to patterns did not include it in the artifact.

This change seeks to always include files that are present in patterns.