### PR TITLE
feat(zip): make bestzip an off-by-default option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ module.exports = (serverless) => {
 };
 ```
 
+### Native Zip
+
+If you wish to use your system's `zip` executable to create archives (can be significantly faster when working with many large archives), set the `nativeZip` option:
+
+```yml
+custom:
+  esbuild:
+    nativeZip: true
+```
+
+**NOTE:*** This will produce non-deterministic archives which causes a Serverless deployment update on every deploy.
+
 ## Usage
 
 ### Automatic compilation

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@commitlint/cli": "^9.1.1",
     "@commitlint/config-conventional": "^9.1.1",
+    "@types/archiver": "^5.1.1",
     "@types/fs-extra": "^9.0.1",
     "@types/jest": "^26.0.14",
     "@types/node": "^12.12.38",
@@ -60,6 +61,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
+    "archiver": "^5.3.0",
     "bestzip": "^2.2.0",
     "chokidar": "^3.4.3",
     "esbuild": ">=0.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,10 +34,11 @@ export interface PackagerOptions {
   scripts?: string[] | string;
 }
 
-export interface Configuration extends Omit<BuildOptions, 'watch' | 'plugins'> {
+export interface Configuration extends Omit<BuildOptions, 'nativeZip' | 'watch' | 'plugins'> {
   packager: 'npm' | 'yarn';
   packagePath: string;
   exclude: string[];
+  nativeZip: boolean;
   watch: WatchConfiguration;
   plugins?: string;
   keepOutputDirectory?: boolean;
@@ -49,6 +50,7 @@ const DEFAULT_BUILD_OPTIONS: Partial<Configuration> = {
   target: 'node10',
   external: [],
   exclude: ['aws-sdk'],
+  nativeZip: false,
   packager: 'npm',
   watch: {
     pattern: './**/*.(js|ts)',
@@ -256,6 +258,7 @@ export class EsbuildServerlessPlugin implements ServerlessPlugin {
 
         // esbuild v0.7.0 introduced config options validation, so I have to delete plugin specific options from esbuild config.
         delete config['exclude'];
+        delete config['nativeZip'];
         delete config['packager'];
         delete config['packagePath'];
         delete config['watch'];

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -75,7 +75,7 @@ export async function pack(this: EsbuildServerlessPlugin) {
     )(files);
 
     const startZip = Date.now();
-    await zip(artifactPath, filesPathList);
+    await zip(artifactPath, filesPathList, this.buildOptions.nativeZip);
     const { size } = fs.statSync(artifactPath);
 
     this.serverless.cli.log(
@@ -157,7 +157,7 @@ export async function pack(this: EsbuildServerlessPlugin) {
         }));
 
       const startZip = Date.now();
-      await zip(artifactPath, filesPathList);
+      await zip(artifactPath, filesPathList, this.buildOptions.nativeZip);
 
       const { size } = fs.statSync(artifactPath);
 


### PR DESCRIPTION
bestzip preserves file timestamps, which causes function zips to be different after every esbuild.

Because there are scenarios where native js zipping is unacceptably slower than native system zip, the option to use it is preserved as an option.

Fixes: #186