### PR TITLE
feat: ignore external module if not declared in package.json

### DIFF
--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -85,7 +85,20 @@ function getProdModules(
 
   // Get versions of all transient modules
   forEach((externalModule) => {
-    // (1) If present in Dev Dependencies
+    // (1) If not present in Dev Dependencies or Dependencies
+    if (
+      !packageJson.dependencies[externalModule.external] &&
+      !packageJson.devDependencies[externalModule.external]
+    ){
+      this.options.verbose &&
+        this.serverless.cli.log(
+          `INFO: Runtime dependency '${externalModule.external}' not found in dependencies or devDependencies. It has been excluded automatically.`
+        );
+        
+      return;
+    }
+    
+    // (2) If present in Dev Dependencies
     if (
       !packageJson.dependencies[externalModule.external] &&
       packageJson.devDependencies[externalModule.external]
@@ -108,8 +121,10 @@ function getProdModules(
         this.serverless.cli.log(
           `INFO: Runtime dependency '${externalModule.external}' found in devDependencies. It has been excluded automatically.`
         );
-    } else {
-      // (2) otherwise let's get the version
+
+      return;
+    }
+      // (3) otherwise let's get the version
 
       // get module package - either from root or local node_modules - will be used for version and peer deps
       const rootModulePackagePath = path.join(
@@ -172,7 +187,6 @@ function getProdModules(
           `WARNING: Could not check for peer dependencies of ${externalModule.external}`
         );
       }
-    }
   }, externalModules);
 
   return prodModules;


### PR DESCRIPTION
## Why we need this change

Resolves #196

If you have a package listed in `external` which is *not* in the package.json dependencies, the plugin will try and install it anyway.

The documentation states the following:

```
Packages that are marked as external and exist in the package.json's dependencies will be installed and included with your build under node_modules.
```

## Change
- aligns the behaviour of `external` with the documentation.