### PR TITLE
fix(pack): local lockfile resolved at wrong location

### DIFF
--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -205,14 +205,14 @@ export async function packExternalModules(this: EsbuildServerlessPlugin) {
       packagePaths: findPackagePaths(),
       allowList: [],
     });
-  }  
+  }
 
   let externals = [];
 
   // get the list of externals only if exclude is not set to *
   if (this.buildOptions.exclude !== '*' && !this.buildOptions.exclude.includes('*')) {
     externals = without(this.buildOptions.exclude, this.buildOptions.external);
-  } 
+  }
 
   if (!externals || !externals.length) {
     return;
@@ -298,7 +298,7 @@ export async function packExternalModules(this: EsbuildServerlessPlugin) {
   );
 
   // (1.a.2) Copy package-lock.json if it exists, to prevent unwanted upgrades
-  const packageLockPath = path.join(path.dirname(rootPackageJsonPath), packager.lockfileName);
+  const packageLockPath = path.join(path.dirname(packageJsonPath), packager.lockfileName);
   const exists = await fse.pathExists(packageLockPath);
   if (exists) {
     this.serverless.cli.log('Package lock found - Using locked versions');


### PR DESCRIPTION
I had a bug today where yarn would try to install my externals with --frozen-lockfile, even from a service in a monorepo. Checked the code, and actually, we were resolving the lockfile from the root package json path - whereas the original PR for this feature stipulates that the lockfile should be sought at the local level - thus determining if we should use frozen lockfile or not.

This will not affect users out of a monorepo.

I am fixing this now, But I really think we should take some time to review the all packaging step, as it has become quite complex PR after PR. But time is hard to find :-).