### PR TITLE
feat: set up concurrency on building the lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ custom:
 
 **NOTE:*** This will produce non-deterministic archives which causes a Serverless deployment update on every deploy.
 
+### Concurrency
+
+If you wish to limit the concurrency of the bundling process (can be very expensive on memory), set the `concurrency` option:
+
+```yml
+custom:
+  esbuild:
+    concurrency: 10
+```
+
+**NOTE:*** This will produce slower builds.
+
 ## Usage
 
 ### Automatic compilation

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "esbuild": ">=0.8",
     "fs-extra": "^9.0.1",
     "globby": "^11.0.1",
+    "p-map": "^4.0.0",
     "ramda": "^0.27.0",
     "string.prototype.matchall": "^4.0.4"
   },


### PR DESCRIPTION
## What has been implemented?

For some use cases, where there is limited system memory available (i.e. GitHub Actions 7GB), esbuild can run out of memory and crash when building a big serverless project (i.e. 50+ lambdas).

In order to overcome that I've added the esbuild option _concurrency_ to only allow as much as _concurrency_ promises running at the same time when building the lambdas.

I could help with the tests, and indeed I tried to work on them, but there is a lot to reestructure in the index.ts before unit tests start to make sense.

Closes #200

## Steps to verify

- Run _serverless package_ command with the esbuild option _concurrency_ as an integer
  - It should limit the concurrent building of the service lambda's to that amount

- Run _serverless package_ command with the esbuild option _concurrency_ as a string
  - It should throw an error with the message:
    - TypeError: Expected `concurrency` to be an integer from 1 and up or `Infinity`, got `a` (string)

- Run _serverless package_ command with **no** esbuild option _concurrency_
  - It should concurrently build all of the service lambda's
