### PR TITLE
Add docs for how to mark individual packages as external

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ custom:
 
 To easily mark all the `dependencies` in `package.json` as `external`, you can utilize `esbuild-node-externals` [plugin](https://www.npmjs.com/package/esbuild-node-externals).
 
+To mark one or more individual packages as external, use the following configuration:
+
+```yml
+custom:
+  esbuild:
+    external:
+      - 'my-package-name'
+      - 'another-package-name'
+```
+
 ### Passing Extra Arguments to Packager
 
 This might be required to resolve some issues on package installation.


### PR DESCRIPTION
In some situations it can be useful to include only some dependencies as external but allowing other dependencies to be bundled, one such example is when creating AWS Edge lambdas which have limit on deployment package sizes.

This commit adds to the docs an example of how to do this which isn't otherwise immediately obviously without going to look at example serverless.yml files.