### PR TITLE
fix(utils): replace `fs.rmdirSync` with `fs.rm`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,7 +131,7 @@ export const zip = async (
     });
 
     // delete the temporary folder
-    fs.rmdirSync(tempDirPath, { recursive: true });
+    fs.rm(tempDirPath, { recursive: true });
   } else {
     const zip = archiver.create('zip');
     const output = fs.createWriteStream(zipPath);
@@ -157,7 +157,7 @@ export const zip = async (
     return new Promise((resolve, reject) => {
       output.on('close', () => {
         // delete the temporary folder
-        fs.rmdirSync(tempDirPath, { recursive: true });
+        fs.rm(tempDirPath, { recursive: true });
 
         resolve();
       });


### PR DESCRIPTION
## Reason

https://github.com/floydspace/serverless-esbuild/issues/226#issuecomment-964867141

I noticed a little deprecation warning. May as well get ahead of it.

## Change

Replace `fs.rmdirSync` with `fs.rm`.