### PR TITLE
feat: added disableIncremental option to completely turn off incremental compilation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export interface Configuration extends Omit<BuildOptions, 'nativeZip' | 'watch' 
   plugins?: string;
   keepOutputDirectory?: boolean;
   packagerOptions?: PackagerOptions;
+  disableIncremental?: boolean;
 }
 
 const DEFAULT_BUILD_OPTIONS: Partial<Configuration> = {
@@ -277,6 +278,9 @@ export class EsbuildServerlessPlugin implements ServerlessPlugin {
   async bundle(incremental = false): Promise<BuildResult[]> {
     this.prepare();
     this.serverless.cli.log(`Compiling to ${this.buildOptions.target} bundle with esbuild...`);
+    if (this.buildOptions.disableIncremental === true) {
+      incremental = false;
+    }
 
     const bundleMapper = async (bundleInfo) => {
       const { entry, func, functionAlias } = bundleInfo;
@@ -305,6 +309,7 @@ export class EsbuildServerlessPlugin implements ServerlessPlugin {
       delete config['keepOutputDirectory'];
       delete config['packagerOptions'];
       delete config['installExtraArgs'];
+      delete config['disableIncremental'];
 
       const bundlePath = entry.substr(0, entry.lastIndexOf('.')) + '.js';
 


### PR DESCRIPTION
**Motivation: preventing a memory leak**

When used in combination with serverless-offline on a typescript codebase of about 200.000 lines of code, my colleagues and I have observed a memory leak that caused in our case about 500Mb to be consumed on each code change triggering a recompilation (as described in  #98). After some experiments with serverless-esbuild's code, it turned out that totally disabling incremental compilation made the problem disappear. Since esbuild is extremely fast, giving up incremental compilation did not affect our development speed, which is why we want to propose to add an option to do that.