### PR TITLE
fix: don't invoke result.rebuild when it is not defined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -310,8 +310,10 @@ export class EsbuildServerlessPlugin implements ServerlessPlugin {
 
       if (this.buildResults) {
         const { result } = this.buildResults.find(({ func: fn }) => fn.name === func.name);
-        await result.rebuild();
-        return { result, bundlePath, func, functionAlias };
+        if (result.rebuild) {
+          await result.rebuild();
+          return { result, bundlePath, func, functionAlias };
+        }
       }
 
       const result = await build(config);


### PR DESCRIPTION
This PR is a follow up to #231 since, when disabling incremental compilation, the `BuildResult` object does not have the rebuild property:
```
export interface BuildResult {
...
  /** Only when "incremental: true" */
  rebuild?: BuildInvalidate;
...
}
```

which makes `await result.rebuild();` throw an error that turns into a bundling error that prevents hot reload from working.