### PR TITLE
fix: allow relative path for function handler

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -9,7 +9,7 @@ export function extractFileNames(
   cwd: string,
   provider: string,
   functions?: Record<string, Serverless.FunctionDefinitionHandler>
-): { entry: string; func: any, functionAlias?: string }[] {
+): { entry: string; func: any; functionAlias?: string }[] {
   // The Google provider will use the entrypoint not from the definition of the
   // handler function, but instead from the package.json:main field, or via a
   // index.js file. This check reads the current package.json in the same way
@@ -36,7 +36,7 @@ export function extractFileNames(
     }
   }
 
-  return Object.keys(functions).map(functionAlias => {
+  return Object.keys(functions).map((functionAlias) => {
     const func = functions[functionAlias];
     const h = func.handler;
     const fnName = path.extname(h);
@@ -46,12 +46,12 @@ export function extractFileNames(
 
     // Check if the .ts files exists. If so return that to watch
     if (fs.existsSync(path.join(cwd, fileName + '.ts'))) {
-      return { entry: fileName + '.ts', func, functionAlias };
+      return { entry: path.relative(cwd, fileName) + '.ts', func, functionAlias };
     }
 
     // Check if the .js files exists. If so return that to watch
     if (fs.existsSync(path.join(cwd, fileName + '.js'))) {
-      return { entry: fileName + '.js', func, functionAlias };
+      return { entry: path.relative(cwd, fileName) + '.js', func, functionAlias };
     }
 
     // Can't find the files. Watch will have an exception anyway. So throw one with error.
@@ -88,7 +88,7 @@ export const flatDep = (deps: JSONObject, filter?: string[], originalObject?: JS
 export const getDepsFromBundle = (bundlePath: string) => {
   const bundleContent = fs.readFileSync(bundlePath, 'utf8');
   const requireMatch = matchAll(bundleContent, /require\("(.*?)"\)/gim);
-  return uniq(Array.from(requireMatch).map(match => match[1]));
+  return uniq(Array.from(requireMatch).map((match) => match[1]));
 };
 
 export const doSharePath = (child, parent) => {
@@ -99,9 +99,9 @@ export const doSharePath = (child, parent) => {
 };
 
 export const providerRuntimeMatcher = Object.freeze({
-  'aws': {
+  aws: {
     'nodejs14.x': 'node14',
     'nodejs12.x': 'node12',
     'nodejs10.x': 'node10',
-  }
+  },
 });

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -44,14 +44,12 @@ export function extractFileNames(
     // replace only last instance to allow the same name for file and handler
     const fileName = h.substring(0, fnNameLastAppearanceIndex);
 
-    // Check if the .ts files exists. If so return that to watch
-    if (fs.existsSync(path.join(cwd, fileName + '.ts'))) {
-      return { entry: path.relative(cwd, fileName) + '.ts', func, functionAlias };
-    }
-
-    // Check if the .js files exists. If so return that to watch
-    if (fs.existsSync(path.join(cwd, fileName + '.js'))) {
-      return { entry: path.relative(cwd, fileName) + '.js', func, functionAlias };
+    const extensions = ['.ts', '.js'];
+    for (const extension of extensions) {
+      // Check if the .{extension} files exists. If so return that to watch
+      if (fs.existsSync(path.join(cwd, fileName + extension))) {
+        return { entry: path.relative(cwd, fileName + extension), func, functionAlias };
+      }
     }
 
     // Can't find the files. Watch will have an exception anyway. So throw one with error.

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -1,0 +1,122 @@
+import * as fs from 'fs-extra';
+import { mocked } from 'ts-jest/utils';
+
+import { extractFileNames } from '../helper';
+
+jest.mock('fs-extra');
+
+const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('extractFileNames', () => {
+  const cwd = process.cwd();
+
+  describe('aws', () => {
+    it('should return entries for handlers which reference files in the working directory', () => {
+      mocked(fs.existsSync).mockReturnValue(true);
+      const functionDefinitions = {
+        function1: {
+          events: [],
+          handler: 'file1.handler',
+        },
+        function2: {
+          events: [],
+          handler: 'file2.handler',
+        },
+      };
+
+      const fileNames = extractFileNames(cwd, 'aws', functionDefinitions);
+
+      expect(fileNames).toStrictEqual([
+        {
+          entry: 'file1.ts',
+          func: functionDefinitions['function1'],
+          functionAlias: 'function1',
+        },
+        {
+          entry: 'file2.ts',
+          func: functionDefinitions['function2'],
+          functionAlias: 'function2',
+        },
+      ]);
+    });
+
+    it('should return entries for handlers which reference files in folders in the working directory', () => {
+      mocked(fs.existsSync).mockReturnValue(true);
+      const functionDefinitions = {
+        function1: {
+          events: [],
+          handler: 'folder/file1.handler',
+        },
+        function2: {
+          events: [],
+          handler: 'folder/file2.handler',
+        },
+      };
+
+      const fileNames = extractFileNames(cwd, 'aws', functionDefinitions);
+
+      expect(fileNames).toStrictEqual([
+        {
+          entry: 'folder/file1.ts',
+          func: functionDefinitions['function1'],
+          functionAlias: 'function1',
+        },
+        {
+          entry: 'folder/file2.ts',
+          func: functionDefinitions['function2'],
+          functionAlias: 'function2',
+        },
+      ]);
+    });
+
+    it('should return entries for handlers which reference files using a relative path in the working directory', () => {
+      mocked(fs.existsSync).mockReturnValue(true);
+      const functionDefinitions = {
+        function1: {
+          events: [],
+          handler: './file1.handler',
+        },
+        function2: {
+          events: [],
+          handler: './file2.handler',
+        },
+      };
+
+      const fileNames = extractFileNames(cwd, 'aws', functionDefinitions);
+
+      expect(fileNames).toStrictEqual([
+        {
+          entry: 'file1.ts',
+          func: functionDefinitions['function1'],
+          functionAlias: 'function1',
+        },
+        {
+          entry: 'file2.ts',
+          func: functionDefinitions['function2'],
+          functionAlias: 'function2',
+        },
+      ]);
+    });
+
+    it('should throw an error if the handlers reference a file which does not exist', () => {
+      mocked(fs.existsSync).mockReturnValue(false);
+      const functionDefinitions = {
+        function1: {
+          events: [],
+          handler: 'file1.handler',
+        },
+        function2: {
+          events: [],
+          handler: 'file2.handler',
+        },
+      };
+
+      expect(() => extractFileNames(cwd, 'aws', functionDefinitions)).toThrowError();
+      expect(consoleSpy).toBeCalled();
+    });
+  });
+});


### PR DESCRIPTION
Resolves #235
Resolves #234

This allows for users to set the function handler using the relative path operator: eg.

```
func1:
  handler: ./file1.handler
```