### PR TITLE
fix: correct package individually relative path for Windows

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import * as os from 'os';
 import { uniq } from 'ramda';
 import * as Serverless from 'serverless';
 import * as matchAll from 'string.prototype.matchall';
@@ -48,7 +49,12 @@ export function extractFileNames(
     for (const extension of extensions) {
       // Check if the .{extension} files exists. If so return that to watch
       if (fs.existsSync(path.join(cwd, fileName + extension))) {
-        return { entry: path.relative(cwd, fileName + extension), func, functionAlias };
+        const entry = path.relative(cwd, fileName + extension);
+        return {
+          entry: os.platform() === 'win32' ? entry.replace(/\\/g, '/') : entry,
+          func,
+          functionAlias,
+        };
       }
     }
 

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -1,4 +1,6 @@
 import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as os from 'os';
 import { mocked } from 'ts-jest/utils';
 
 import { extractFileNames } from '../helper';
@@ -98,6 +100,28 @@ describe('extractFileNames', () => {
           entry: 'file2.ts',
           func: functionDefinitions['function2'],
           functionAlias: 'function2',
+        },
+      ]);
+    });
+
+    it('should return entries for handlers on a Windows platform', () => {
+      mocked(fs.existsSync).mockReturnValue(true);
+      jest.spyOn(path, 'relative').mockReturnValueOnce('src\\file1.ts');
+      jest.spyOn(os, 'platform').mockReturnValueOnce('win32');
+      const functionDefinitions = {
+        function1: {
+          events: [],
+          handler: 'file1.handler',
+        },
+      };
+
+      const fileNames = extractFileNames(cwd, 'aws', functionDefinitions);
+
+      expect(fileNames).toStrictEqual([
+        {
+          entry: 'src/file1.ts',
+          func: functionDefinitions['function1'],
+          functionAlias: 'function1',
         },
       ]);
     });


### PR DESCRIPTION
Fixes #243

## Why
On Windows `path.relative` adds `\` to paths instead of `/` and esbuild does not like this when we pass it in as an entrypoint.

## What
Replace all `\` with `/` in paths for Windows.

## How this was tested
Unit Tests