### PR TITLE
fix(npm): updated getProdDependencies to support npm v7+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5713,6 +5713,15 @@
       "integrity": "sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==",
       "dev": true
     },
+    "mock-spawn": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/mock-spawn/-/mock-spawn-0.2.6.tgz",
+      "integrity": "sha1-s5wVocBnUEMQFEFR8sHeNE0Dk38=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.x"
+      }
+    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "jest": "^26.4.2",
     "lint-staged": "^11.1.2",
     "mock-fs": "^4.12.0",
+    "mock-spawn": "^0.2.6",
     "prettier": "^2.3.2",
     "semantic-release": "^17.0.8",
     "ts-jest": "^26.4.0",

--- a/src/tests/packagers/npm.test.ts
+++ b/src/tests/packagers/npm.test.ts
@@ -1,0 +1,77 @@
+import { NPM } from '../../packagers/npm';
+import * as path from 'path';
+import * as mockSpawn from 'mock-spawn';
+
+describe('test NPM class', () => {
+  it('should properly get the dependencies list', async () => {
+    jest.resetAllMocks();
+
+    const mySpawn = mockSpawn();
+    require('child_process').spawn = mySpawn;
+
+    mySpawn.sequence.add(mySpawn.simple(0, '6.0.0'));
+    mySpawn.sequence.add(mySpawn.simple(0, '{"dependencies":{}}'));
+
+    const npm = new NPM();
+    const dependencies = await npm.getProdDependencies(path.join('./'));
+    
+    expect(mySpawn.calls.length).toStrictEqual(2);
+    expect(mySpawn.calls[0].args).toStrictEqual(['--version']);
+    expect(mySpawn.calls[1].args).toStrictEqual(['ls', '-json', '-prod']);
+    expect(dependencies).toStrictEqual({'dependencies':{}});
+    jest.resetAllMocks();
+  });
+
+  it('should properly get the dependencies list w/ depth', async () => {
+    jest.resetAllMocks();
+
+    const mySpawn = mockSpawn();
+    require('child_process').spawn = mySpawn;
+
+    mySpawn.sequence.add(mySpawn.simple(0, '{"dependencies":{}}'));
+
+    const npm = new NPM();
+    const dependencies = await npm.getProdDependencies(path.join('./'), 2);
+    
+    expect(mySpawn.calls.length).toStrictEqual(1);
+    expect(mySpawn.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-depth=2']);
+    expect(dependencies).toStrictEqual({'dependencies':{}});
+    jest.resetAllMocks();
+  });
+
+  it('should properly get the dependencies list (npm version >= 7)', async () => {
+    jest.resetAllMocks();
+
+    const mySpawn = mockSpawn();
+    require('child_process').spawn = mySpawn;
+
+    mySpawn.sequence.add(mySpawn.simple(0, '7.0.0'));
+    mySpawn.sequence.add(mySpawn.simple(0, '{"dependencies":{}}'));
+
+    const npm = new NPM();
+    const dependencies = await npm.getProdDependencies(path.join('./'));
+    
+    expect(mySpawn.calls.length).toStrictEqual(2);
+    expect(mySpawn.calls[0].args).toStrictEqual(['--version']);
+    expect(mySpawn.calls[1].args).toStrictEqual(['ls', '-json', '-prod', '-all']);
+    expect(dependencies).toStrictEqual({'dependencies':{}});
+    jest.resetAllMocks();
+  });
+
+  it('should properly get the dependencies list w/ depth (npm version >= 7)', async () => {
+    jest.resetAllMocks();
+
+    const mySpawn = mockSpawn();
+    require('child_process').spawn = mySpawn;
+
+    mySpawn.sequence.add(mySpawn.simple(0, '{"dependencies":{}}'));
+
+    const npm = new NPM();
+    const dependencies = await npm.getProdDependencies(path.join('./'), 2);
+    
+    expect(mySpawn.calls.length).toStrictEqual(1);
+    expect(mySpawn.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-depth=2']);
+    expect(dependencies).toStrictEqual({'dependencies':{}});
+    jest.resetAllMocks();
+  });
+});

--- a/src/tests/packagers/npm.test.ts
+++ b/src/tests/packagers/npm.test.ts
@@ -3,75 +3,58 @@ import * as path from 'path';
 import * as mockSpawn from 'mock-spawn';
 
 describe('test NPM class', () => {
+  let spawnSpy = mockSpawn();
+
+  beforeEach(() => {
+    spawnSpy = mockSpawn();
+    require('child_process').spawn = spawnSpy;
+  });
+
   it('should properly get the dependencies list', async () => {
-    jest.resetAllMocks();
-
-    const mySpawn = mockSpawn();
-    require('child_process').spawn = mySpawn;
-
-    mySpawn.sequence.add(mySpawn.simple(0, '6.0.0'));
-    mySpawn.sequence.add(mySpawn.simple(0, '{"dependencies":{}}'));
+    spawnSpy.sequence.add(spawnSpy.simple(0, '6.0.0'));
+    spawnSpy.sequence.add(spawnSpy.simple(0, '{"dependencies":{}}'));
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'));
     
-    expect(mySpawn.calls.length).toStrictEqual(2);
-    expect(mySpawn.calls[0].args).toStrictEqual(['--version']);
-    expect(mySpawn.calls[1].args).toStrictEqual(['ls', '-json', '-prod']);
+    expect(spawnSpy.calls.length).toStrictEqual(2);
+    expect(spawnSpy.calls[0].args).toStrictEqual(['--version']);
+    expect(spawnSpy.calls[1].args).toStrictEqual(['ls', '-json', '-prod']);
     expect(dependencies).toStrictEqual({'dependencies':{}});
-    jest.resetAllMocks();
   });
 
   it('should properly get the dependencies list w/ depth', async () => {
-    jest.resetAllMocks();
-
-    const mySpawn = mockSpawn();
-    require('child_process').spawn = mySpawn;
-
-    mySpawn.sequence.add(mySpawn.simple(0, '{"dependencies":{}}'));
+    spawnSpy.sequence.add(spawnSpy.simple(0, '{"dependencies":{}}'));
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'), 2);
     
-    expect(mySpawn.calls.length).toStrictEqual(1);
-    expect(mySpawn.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-depth=2']);
+    expect(spawnSpy.calls.length).toStrictEqual(1);
+    expect(spawnSpy.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-depth=2']);
     expect(dependencies).toStrictEqual({'dependencies':{}});
-    jest.resetAllMocks();
   });
 
   it('should properly get the dependencies list (npm version >= 7)', async () => {
-    jest.resetAllMocks();
-
-    const mySpawn = mockSpawn();
-    require('child_process').spawn = mySpawn;
-
-    mySpawn.sequence.add(mySpawn.simple(0, '7.0.0'));
-    mySpawn.sequence.add(mySpawn.simple(0, '{"dependencies":{}}'));
+    spawnSpy.sequence.add(spawnSpy.simple(0, '7.0.0'));
+    spawnSpy.sequence.add(spawnSpy.simple(0, '{"dependencies":{}}'));
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'));
     
-    expect(mySpawn.calls.length).toStrictEqual(2);
-    expect(mySpawn.calls[0].args).toStrictEqual(['--version']);
-    expect(mySpawn.calls[1].args).toStrictEqual(['ls', '-json', '-prod', '-all']);
+    expect(spawnSpy.calls.length).toStrictEqual(2);
+    expect(spawnSpy.calls[0].args).toStrictEqual(['--version']);
+    expect(spawnSpy.calls[1].args).toStrictEqual(['ls', '-json', '-prod', '-all']);
     expect(dependencies).toStrictEqual({'dependencies':{}});
-    jest.resetAllMocks();
   });
 
   it('should properly get the dependencies list w/ depth (npm version >= 7)', async () => {
-    jest.resetAllMocks();
-
-    const mySpawn = mockSpawn();
-    require('child_process').spawn = mySpawn;
-
-    mySpawn.sequence.add(mySpawn.simple(0, '{"dependencies":{}}'));
+    spawnSpy.sequence.add(spawnSpy.simple(0, '{"dependencies":{}}'));
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'), 2);
     
-    expect(mySpawn.calls.length).toStrictEqual(1);
-    expect(mySpawn.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-depth=2']);
+    expect(spawnSpy.calls.length).toStrictEqual(1);
+    expect(spawnSpy.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-depth=2']);
     expect(dependencies).toStrictEqual({'dependencies':{}});
-    jest.resetAllMocks();
   });
 });


### PR DESCRIPTION
Fixes: https://github.com/floydspace/serverless-esbuild/issues/144
Module dependencies are missing for the externals for npm v7+