### PR TITLE
fix: error when metafile option is specified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -315,14 +315,6 @@ export class EsbuildServerlessPlugin implements ServerlessPlugin {
       }
 
       const result = await build(config);
-
-      if (config.metafile) {
-        fs.writeFileSync(
-          path.join(this.buildDirPath, `${trimExtension(entry)}-meta.json`),
-          JSON.stringify(result.metafile, null, 2)
-        );
-      }
-
       return { result, bundlePath, func, functionAlias };
     };
     this.serverless.cli.log(


### PR DESCRIPTION
Based on https://github.com/floydspace/serverless-esbuild/issues/121 it seems like at one point it's necessary to write the metafile returned from esbuild's JS API manually. However, the API must have changed since then which led to the following error:

```
  TypeError: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
      at Object.writeFileSync (node:fs:2146:5)
      at EsbuildServerlessPlugin.<anonymous> (/Users/marslan/Metaphor/app/node_modules/serverless-esbuild/dist/index.js:233:24)
      at Generator.next (<anonymous>)
      at fulfilled (/Users/marslan/Metaphor/app/node_modules/serverless-esbuild/dist/index.js:5:58)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

Luckily, it seems that esbuild will happen output the metafile directly so there's no need for this part of the code any more.