### PR TITLE
fix: do not set package artefact for non-node functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -392,23 +392,12 @@ export class EsbuildServerlessPlugin implements ServerlessPlugin {
       path.join(this.serviceDirPath, SERVERLESS_FOLDER)
     );
 
-    if (this.options.function) {
-      const fn = service.getFunction(this.options.function);
-      fn.package.artifact = path.join(
-        this.serviceDirPath,
-        SERVERLESS_FOLDER,
-        path.basename(fn.package.artifact)
-      );
-      return;
-    }
-
-    if (service.package.individually) {
-      const functionNames = Object.keys(this.functions);
-      functionNames.forEach((name) => {
-        service.getFunction(name).package.artifact = path.join(
+    if (service.package.individually || this.options.function) {
+      Object.values(this.functions).forEach((func) => {
+        func.package.artifact = path.join(
           this.serviceDirPath,
           SERVERLESS_FOLDER,
-          path.basename(service.getFunction(name).package.artifact)
+          path.basename(func.package.artifact)
         );
       });
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -403,7 +403,7 @@ export class EsbuildServerlessPlugin implements ServerlessPlugin {
     }
 
     if (service.package.individually) {
-      const functionNames = service.getAllFunctions();
+      const functionNames = Object.keys(this.functions);
       functionNames.forEach((name) => {
         service.getFunction(name).package.artifact = path.join(
           this.serviceDirPath,


### PR DESCRIPTION
If you ask serverless to package your functions individually, the plugin will try to package everything, causing a crash if you have functions that were already filtered out by the code in `get functions()`.
(You can work around this by adding a dummy "- package: { artifact: '' }` property of the function.)

This just changes what functions need to be packaged to the ones that are valid.