### PR TITLE
fix: use esModuleInterop and remove tests from package

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,9 +1,9 @@
-import * as fs from 'fs-extra';
-import * as path from 'path';
-import * as os from 'os';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
 import { uniq } from 'ramda';
-import * as Serverless from 'serverless';
-import * as matchAll from 'string.prototype.matchall';
+import Serverless from 'serverless';
+import matchAll from 'string.prototype.matchall';
 import { JSONObject } from './types';
 
 export function extractFileNames(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import { build, BuildResult, BuildOptions, Plugin } from 'esbuild';
-import * as fs from 'fs-extra';
-import * as globby from 'globby';
-import * as path from 'path';
-import * as pMap from 'p-map';
+import { build, BuildResult, BuildOptions } from 'esbuild';
+import fs from 'fs-extra';
+import globby from 'globby';
+import path from 'path';
+import pMap from 'p-map';
 import { concat, always, memoizeWith, mergeRight } from 'ramda';
-import * as Serverless from 'serverless';
-import * as ServerlessPlugin from 'serverless/classes/Plugin';
-import * as chokidar from 'chokidar';
+import Serverless from 'serverless';
+import ServerlessPlugin from 'serverless/classes/Plugin';
+import chokidar from 'chokidar';
 
 import { extractFileNames, providerRuntimeMatcher } from './helper';
 import { packExternalModules } from './pack-externals';
@@ -15,43 +15,13 @@ import { preOffline } from './pre-offline';
 import { preLocal } from './pre-local';
 import { trimExtension } from './utils';
 import { BUILD_FOLDER, ONLY_PREFIX, SERVERLESS_FOLDER, WORK_FOLDER } from './constants';
-
-type Plugins = Plugin[];
-type ReturnPluginsFn = (sls: Serverless) => Plugins;
-
-interface OptionsExtended extends Serverless.Options {
-  verbose?: boolean;
-}
-
-export interface WatchConfiguration {
-  pattern?: string[] | string;
-  ignore?: string[] | string;
-}
-
-export interface PackagerOptions {
-  scripts?: string[] | string;
-}
-
-export interface Configuration extends Omit<BuildOptions, 'nativeZip' | 'watch' | 'plugins'> {
-  concurrency?: number;
-  packager: 'npm' | 'yarn';
-  packagePath: string;
-  exclude: '*' | string[];
-  nativeZip: boolean;
-  watch: WatchConfiguration;
-  installExtraArgs: string[];
-  plugins?: string;
-  keepOutputDirectory?: boolean;
-  packagerOptions?: PackagerOptions;
-  disableIncremental?: boolean;
-}
-
-export interface FunctionBuildResult {
-  result: BuildResult;
-  bundlePath: string;
-  func: Serverless.FunctionDefinitionHandler;
-  functionAlias: string;
-}
+import {
+  Configuration,
+  FunctionBuildResult,
+  OptionsExtended,
+  Plugins,
+  ReturnPluginsFn,
+} from './types';
 
 const DEFAULT_BUILD_OPTIONS: Partial<Configuration> = {
   bundle: true,
@@ -69,7 +39,7 @@ const DEFAULT_BUILD_OPTIONS: Partial<Configuration> = {
   packagerOptions: {},
 };
 
-export class EsbuildServerlessPlugin implements ServerlessPlugin {
+class EsbuildServerlessPlugin implements ServerlessPlugin {
   serviceDirPath: string;
   workDirPath: string;
   buildDirPath: string;
@@ -419,4 +389,4 @@ export class EsbuildServerlessPlugin implements ServerlessPlugin {
   }
 }
 
-module.exports = EsbuildServerlessPlugin;
+export = EsbuildServerlessPlugin;

--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -1,5 +1,5 @@
-import * as fse from 'fs-extra';
-import * as path from 'path';
+import fse from 'fs-extra';
+import path from 'path';
 import {
   compose,
   forEach,
@@ -28,7 +28,7 @@ import * as Packagers from './packagers';
 import { JSONObject } from './types';
 import { findProjectRoot, findUp } from './utils';
 
-import type { EsbuildServerlessPlugin } from './index';
+import EsbuildServerlessPlugin from './index';
 
 function rebaseFileReferences(pathToPackageRoot: string, moduleVersion: string) {
   if (/^(?:file:[^/]{2}|\.\/|\.\.\/)/.test(moduleVersion)) {

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs-extra';
-import * as globby from 'globby';
-import * as path from 'path';
+import fs from 'fs-extra';
+import globby from 'globby';
+import path from 'path';
 import {
   intersection,
   isEmpty,
@@ -13,8 +13,8 @@ import {
   test,
   without,
 } from 'ramda';
-import * as semver from 'semver';
-import { EsbuildServerlessPlugin } from '.';
+import semver from 'semver';
+import EsbuildServerlessPlugin from '.';
 import { ONLY_PREFIX, SERVERLESS_FOLDER } from './constants';
 import { doSharePath, flatDep, getDepsFromBundle } from './helper';
 import * as Packagers from './packagers';

--- a/src/pre-local.ts
+++ b/src/pre-local.ts
@@ -1,4 +1,4 @@
-import { EsbuildServerlessPlugin } from '.';
+import EsbuildServerlessPlugin from '.';
 
 export function preLocal(this: EsbuildServerlessPlugin) {
   this.serviceDirPath = this.buildDirPath;

--- a/src/pre-offline.ts
+++ b/src/pre-offline.ts
@@ -1,6 +1,6 @@
 import { relative } from 'path';
 import { assocPath } from 'ramda';
-import { EsbuildServerlessPlugin } from '.';
+import EsbuildServerlessPlugin from '.';
 
 export function preOffline(this: EsbuildServerlessPlugin) {
   // Set offline location automatically if not set manually

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs-extra';
-import * as path from 'path';
-import * as os from 'os';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
 import { mocked } from 'ts-jest/utils';
 
 import { extractFileNames } from '../helper';

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,0 +1,168 @@
+import Serverless from 'serverless';
+import Service from 'serverless/classes/Service';
+import EsbuildServerlessPlugin from '../index';
+import { OptionsExtended } from '../types';
+
+import fs from 'fs-extra';
+
+jest.mock('fs-extra');
+
+const mockProvider: Service['provider'] = {
+  name: 'aws',
+  region: 'us-east-1',
+  stage: 'dev',
+  runtime: 'nodejs12.x',
+  compiledCloudFormationTemplate: {
+    Resources: {},
+  },
+  versionFunctions: true,
+};
+
+const mockGetFunction = jest.fn();
+
+const packageIndividuallyService: Partial<Service> = {
+  functions: {
+    hello1: { handler: 'hello1.handler', events: [], package: { artifact: 'hello1' } },
+    hello2: { handler: 'hello2.handler', events: [], package: { artifact: 'hello2' } },
+  },
+  package: { individually: true },
+  provider: mockProvider,
+  getFunction: mockGetFunction,
+};
+
+const packageService: Partial<Service> = {
+  functions: {
+    hello1: { handler: 'hello1.handler', events: [] },
+    hello2: { handler: 'hello2.handler', events: [] },
+  },
+  package: { artifact: 'hello' },
+  provider: mockProvider,
+  getFunction: mockGetFunction,
+};
+
+const mockServerlessConfig = (serviceOverride?: Partial<Service>): Serverless => {
+  const service = {
+    ...packageIndividuallyService,
+    ...serviceOverride,
+  } as Service;
+
+  return {
+    service,
+    config: {
+      servicePath: '/workDir',
+    },
+  } as Partial<Serverless> as Serverless;
+};
+
+const mockOptions: OptionsExtended = {
+  region: 'us-east-1',
+  stage: 'dev',
+};
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('Move Artifacts', () => {
+  it('should copy files from the esbuild folder to the serverless folder', async () => {
+    const plugin = new EsbuildServerlessPlugin(mockServerlessConfig(), mockOptions);
+
+    await plugin.moveArtifacts();
+
+    expect(fs.copy).toBeCalledWith('/workDir/.esbuild/.serverless', '/workDir/.serverless');
+  });
+
+  describe('function option', () => {
+    it('should update the selected functions base path to the serverless folder', async () => {
+      mockGetFunction.mockReturnValue(packageIndividuallyService.functions.hello1);
+      const plugin = new EsbuildServerlessPlugin(mockServerlessConfig(), {
+        ...mockOptions,
+        function: 'hello1',
+      });
+
+      await plugin.moveArtifacts();
+
+      expect(plugin.functions).toMatchInlineSnapshot(`
+        Object {
+          "hello1": Object {
+            "events": Array [],
+            "handler": "hello1.handler",
+            "package": Object {
+              "artifact": "/workDir/.serverless/hello1",
+            },
+          },
+        }
+      `);
+    });
+  });
+
+  describe('package individually', () => {
+    it('should update function package artifacts base path to the serverless folder', async () => {
+      const plugin = new EsbuildServerlessPlugin(mockServerlessConfig(), mockOptions);
+
+      await plugin.moveArtifacts();
+
+      expect(plugin.functions).toMatchInlineSnapshot(`
+        Object {
+          "hello1": Object {
+            "events": Array [],
+            "handler": "hello1.handler",
+            "package": Object {
+              "artifact": "/workDir/.serverless/hello1",
+            },
+          },
+          "hello2": Object {
+            "events": Array [],
+            "handler": "hello2.handler",
+            "package": Object {
+              "artifact": "/workDir/.serverless/hello2",
+            },
+          },
+        }
+      `);
+    });
+
+    it('should only update the base path of node functions', async () => {
+      const plugin = new EsbuildServerlessPlugin(
+        mockServerlessConfig({
+          functions: {
+            ...packageIndividuallyService.functions,
+            hello3: { handler: 'hello3.handler', events: [], runtime: 'python2.7' },
+          },
+        }),
+        mockOptions
+      );
+
+      await plugin.moveArtifacts();
+
+      expect(plugin.functions).toMatchInlineSnapshot(`
+        Object {
+          "hello1": Object {
+            "events": Array [],
+            "handler": "hello1.handler",
+            "package": Object {
+              "artifact": "/workDir/.serverless/hello1",
+            },
+          },
+          "hello2": Object {
+            "events": Array [],
+            "handler": "hello2.handler",
+            "package": Object {
+              "artifact": "/workDir/.serverless/hello2",
+            },
+          },
+        }
+      `);
+    });
+  });
+
+  describe('service package', () => {
+    it('should update the service package artifact base path to the serverless folder', async () => {
+      const plugin = new EsbuildServerlessPlugin(mockServerlessConfig(packageService), mockOptions);
+
+      await plugin.moveArtifacts();
+
+      expect(plugin.serverless.service.package.artifact).toBe('/workDir/.serverless/hello');
+    });
+  });
+});

--- a/src/tests/pack.test.ts
+++ b/src/tests/pack.test.ts
@@ -1,10 +1,10 @@
-import { FunctionBuildResult } from '..';
 import { filterFilesForZipPackage, pack } from '../pack';
 import * as utils from '../utils';
 
-import * as fs from 'fs-extra';
-import * as globby from 'globby';
+import fs from 'fs-extra';
+import globby from 'globby';
 import { mocked } from 'ts-jest/utils';
+import { FunctionBuildResult } from '../types';
 
 jest.mock('globby');
 jest.mock('fs-extra');

--- a/src/tests/packagers/npm.test.ts
+++ b/src/tests/packagers/npm.test.ts
@@ -1,6 +1,6 @@
 import { NPM } from '../../packagers/npm';
-import * as path from 'path';
-import * as mockSpawn from 'mock-spawn';
+import path from 'path';
+import mockSpawn from 'mock-spawn';
 
 describe('test NPM class', () => {
   let spawnSpy = mockSpawn();
@@ -16,11 +16,11 @@ describe('test NPM class', () => {
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'));
-    
+
     expect(spawnSpy.calls.length).toStrictEqual(2);
     expect(spawnSpy.calls[0].args).toStrictEqual(['--version']);
     expect(spawnSpy.calls[1].args).toStrictEqual(['ls', '-json', '-prod']);
-    expect(dependencies).toStrictEqual({'dependencies':{}});
+    expect(dependencies).toStrictEqual({ dependencies: {} });
   });
 
   it('should properly get the dependencies list w/ depth', async () => {
@@ -28,10 +28,10 @@ describe('test NPM class', () => {
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'), 2);
-    
+
     expect(spawnSpy.calls.length).toStrictEqual(1);
     expect(spawnSpy.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-depth=2']);
-    expect(dependencies).toStrictEqual({'dependencies':{}});
+    expect(dependencies).toStrictEqual({ dependencies: {} });
   });
 
   it('should properly get the dependencies list (npm version >= 7)', async () => {
@@ -40,11 +40,11 @@ describe('test NPM class', () => {
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'));
-    
+
     expect(spawnSpy.calls.length).toStrictEqual(2);
     expect(spawnSpy.calls[0].args).toStrictEqual(['--version']);
     expect(spawnSpy.calls[1].args).toStrictEqual(['ls', '-json', '-prod', '-all']);
-    expect(dependencies).toStrictEqual({'dependencies':{}});
+    expect(dependencies).toStrictEqual({ dependencies: {} });
   });
 
   it('should properly get the dependencies list w/ depth (npm version >= 7)', async () => {
@@ -52,9 +52,9 @@ describe('test NPM class', () => {
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'), 2);
-    
+
     expect(spawnSpy.calls.length).toStrictEqual(1);
     expect(spawnSpy.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-depth=2']);
-    expect(dependencies).toStrictEqual({'dependencies':{}});
+    expect(dependencies).toStrictEqual({ dependencies: {} });
   });
 });

--- a/src/tests/packagers/npm.test.ts
+++ b/src/tests/packagers/npm.test.ts
@@ -1,6 +1,4 @@
 import { NPM, NpmV6Deps, NpmV7Deps } from '../../packagers/npm';
-import path from 'path';
-import mockSpawn from 'mock-spawn';
 import { DependenciesResult } from '../../types';
 import * as utils from '../../utils';
 

--- a/src/tests/util.test.ts
+++ b/src/tests/util.test.ts
@@ -1,5 +1,5 @@
 import { findProjectRoot } from '../utils';
-import * as path from 'path';
+import path from 'path';
 
 describe('utils/findProjectRoot', () => {
   it('should properly Find a Project Root.', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,48 @@
+import { BuildOptions, BuildResult, Plugin } from 'esbuild';
+import Serverless from 'serverless';
+
+export type Plugins = Plugin[];
+export type ReturnPluginsFn = (sls: Serverless) => Plugins;
+
+export interface OptionsExtended extends Serverless.Options {
+  verbose?: boolean;
+}
+
+export interface WatchConfiguration {
+  pattern?: string[] | string;
+  ignore?: string[] | string;
+}
+
+export interface PackagerOptions {
+  scripts?: string[] | string;
+}
+
+export interface Configuration extends Omit<BuildOptions, 'nativeZip' | 'watch' | 'plugins'> {
+  concurrency?: number;
+  packager: 'npm' | 'yarn';
+  packagePath: string;
+  exclude: '*' | string[];
+  nativeZip: boolean;
+  watch: WatchConfiguration;
+  installExtraArgs: string[];
+  plugins?: string;
+  keepOutputDirectory?: boolean;
+  packagerOptions?: PackagerOptions;
+  disableIncremental?: boolean;
+}
+
+export interface FunctionBuildResult {
+  result: BuildResult;
+  bundlePath: string;
+  func: Serverless.FunctionDefinitionHandler;
+  functionAlias: string;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type JSONObject = any;
 
 export interface IFile {
-  readonly localPath: string
-  readonly rootPath: string
+  readonly localPath: string;
+  readonly rootPath: string;
 }
 export type IFiles = readonly IFile[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
 import { bestzip } from 'bestzip';
-import * as archiver from 'archiver';
-import * as childProcess from 'child_process';
-import * as fs from 'fs-extra';
-import * as path from 'path';
-import * as os from 'os';
+import archiver from 'archiver';
+import childProcess from 'child_process';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
 import { join } from 'ramda';
 import { IFiles } from './types';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,14 @@
     "module": "commonjs",
     "target": "es6",
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "esModuleInterop": true
   },
   "include": [
     "src"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "src/tests"
   ]
 }


### PR DESCRIPTION
## Why
While working on https://github.com/floydspace/serverless-esbuild/pull/261 I tried to write some unit tests involving the `EsbuildServerlessPlugin` class but I could not import it without Typescript complaining in Jest. I tried both `import EsbuildServerlessPlugin * from './index"` and `import {EsbuildServerlessPlugin} * from './index"`

<img width="823" alt="image" src="https://user-images.githubusercontent.com/18017094/152627137-ee9506f1-fdc3-4823-916a-dd37da375831.png">

Happy to go with another approach if you can tell me something else which works 🤷 .

In order to overcome this in the test I had to convert the `module.exports = EsbuildServerlessPlugin` to `exports = EsbuildServerlessPlugin`. This complained about other things being exported in the file so I moved all the type definitions to `types.ts`. This still produces the desired `module.exports = EsbuildServerlessPlugin` in the output `index.js`.

This approach seems to work for both the type import in various files and for the actual class import within Jest test files.

## Change

- Enable `esModuleInterop` in tsconfig
- Exclude `src/tests` from final package
- Update `import * as X from Y` imports to be `import X from Y`.
- Move type exports from `index.ts` into `types.ts`
- Add some `index.ts` unit tests.

Plugin still works. I confirmed this against the `examples` folder. 