### PR TITLE
fix(external): update npm and yarn dependency detection

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -91,7 +91,7 @@ export const flatDep = (
       ]);
     }
 
-    // This is a nested dependency so we don't need to include it in the exclude
+    // This is a nested dependency so we don't need to include it in the bundle
     return uniq([...acc, ...flatDep(details.dependencies, undefined, rootDeps)]);
   }, []);
 };

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -75,7 +75,7 @@ export const flatDep = (
   deps: DependencyMap | undefined,
   filter?: string[],
   rootDeps?: DependencyMap
-) => {
+): string[] => {
   if (!deps) return [];
 
   // keep tracks of the rootDeps when nested
@@ -83,8 +83,14 @@ export const flatDep = (
 
   return Object.entries(deps).reduce((acc, [depName, details]) => {
     if (filter && !filter.includes(depName)) return acc;
-    const dependencies = details.isRootDep ? rootDeps[depName].dependencies : details.dependencies;
-    return uniq([...acc, depName, ...flatDep(dependencies, undefined, rootDeps)]);
+    if (details.isRootDep || filter?.includes(depName)) {
+      return uniq([
+        ...acc,
+        depName,
+        ...flatDep(rootDeps[depName].dependencies, undefined, rootDeps),
+      ]);
+    }
+    return uniq([...acc, ...flatDep(details.dependencies, undefined, rootDeps)]);
   }, []);
 };
 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -87,7 +87,7 @@ export const flatDep = (root: DependencyMap, rootDepsFilter: string[]): string[]
       if (filter && !filter.includes(depName)) return;
 
       if (details.isRootDep || filter) {
-        // We've already have this root dep and it's dependencies - skip this iteration
+        // We already have this root dep and it's dependencies - skip this iteration
         if (flattenedDependencies.has(depName)) return;
 
         recursiveFind(root[depName].dependencies);

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -83,7 +83,7 @@ export const flatDep = (
 
   return Object.entries(deps).reduce((acc, [depName, details]) => {
     if (filter && !filter.includes(depName)) return acc;
-    const dependencies = details.resolved ? rootDeps[depName].dependencies : details.dependencies;
+    const dependencies = details.isRootDep ? rootDeps[depName].dependencies : details.dependencies;
     return uniq([...acc, depName, ...flatDep(dependencies, undefined, rootDeps)]);
   }, []);
 };

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -90,6 +90,8 @@ export const flatDep = (
         ...flatDep(rootDeps[depName].dependencies, undefined, rootDeps),
       ]);
     }
+
+    // This is a nested dependency so we don't need to include it in the exclude
     return uniq([...acc, ...flatDep(details.dependencies, undefined, rootDeps)]);
   }, []);
 };

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -80,16 +80,14 @@ export const flatDep = (root: DependencyMap, rootDepsFilter: string[]): string[]
    * @param filter the dependencies to get from this tree
    */
   const recursiveFind = (deps: DependencyMap | undefined, filter?: string[]) => {
-    if (!deps) {
-      return;
-    }
+    if (!deps) return;
 
     Object.entries(deps).forEach(([depName, details]) => {
       // only for root level dependencies
       if (filter && !filter.includes(depName)) return;
 
       if (details.isRootDep || filter) {
-        // We've already seen this dep and it's dependencies - skip this iteration
+        // We've already have this root dep and it's dependencies - skip this iteration
         if (flattenedDependencies.has(depName)) return;
 
         recursiveFind(root[depName].dependencies);
@@ -97,6 +95,8 @@ export const flatDep = (root: DependencyMap, rootDepsFilter: string[]): string[]
         return;
       }
 
+      // This is a nested dependency and will be included by default when we include it's parent
+      // We just need to check if we fulfil all it's dependencies
       recursiveFind(details.dependencies);
     });
   };

--- a/src/packagers/npm.ts
+++ b/src/packagers/npm.ts
@@ -152,7 +152,7 @@ export class NPM implements Packager {
               isRootDep: true,
             };
           }
-          if (tree._deduped || (Object.keys(tree._dependencies).length && !tree.dependencies)) {
+          if (tree._deduped || (!isEmpty(tree._dependencies) && !tree.dependencies)) {
             // Edge case - When it is de-duped this record will not contain the dependency tree.
             // _deduped is for v6 (Object.keys(tree._dependencies).length && !tree.dependencies) for v7
             // We can just ignore storing this at the root because it does not contain the tree we are after
@@ -176,7 +176,7 @@ export class NPM implements Packager {
             rootDeps[name] ??= {
               version: tree.version,
               ...(tree.dependencies &&
-                Object.keys(tree.dependencies).length && {
+                !isEmpty(tree.dependencies) && {
                   dependencies: convertTrees(tree.dependencies, rootDeps, {}),
                 }),
             };
@@ -188,7 +188,7 @@ export class NPM implements Packager {
         deps[name] ??= {
           version: tree.version,
           ...(tree.dependencies &&
-            Object.keys(tree.dependencies).length && {
+            !isEmpty(tree.dependencies) && {
               dependencies: convertTrees(tree.dependencies, rootDeps, {}),
             }),
         };

--- a/src/packagers/npm.ts
+++ b/src/packagers/npm.ts
@@ -145,8 +145,9 @@ export class NPM implements Packager {
         if (tree.path === path.join(basePath, 'node_modules', name)) {
           // Module path is in the root folder
 
-          // Set it as resolved
+          // If this isn't the root of the tree
           if (rootDeps !== deps) {
+            // Set it as resolved
             deps[name] ??= {
               version: tree.version,
               isRootDep: true,
@@ -172,7 +173,7 @@ export class NPM implements Packager {
             //   "peerDependencies": {}
             // }
           } else {
-            // This is a root node_modules dependency. When rootDeps = deps, this will just overwrite the resolved declaration above
+            // This is a root node_modules dependency
             rootDeps[name] ??= {
               version: tree.version,
               ...(tree.dependencies &&

--- a/src/packagers/npm.ts
+++ b/src/packagers/npm.ts
@@ -119,7 +119,7 @@ export class NPM implements Packager {
             // Set it as resolved
             deps[name] = {
               version: tree.version,
-              resolved: true,
+              isRootDep: true,
             };
             if (Object.keys(tree._dependencies).length && !tree.dependencies) {
               // Edge case - When it is de-duped this record will not contain the dependency tree.

--- a/src/packagers/npm.ts
+++ b/src/packagers/npm.ts
@@ -1,8 +1,37 @@
 import { any, isEmpty, reduce, replace, split, startsWith } from 'ramda';
+import * as path from 'path';
 
-import { JSONObject } from '../types';
+import { DependenciesResult, DependencyMap, JSONObject } from '../types';
 import { SpawnError, spawnProcess } from '../utils';
 import { Packager } from './packager';
+
+type NpmMap = Record<string, NpmTree>;
+
+interface NpmTree {
+  name: string;
+  version: string;
+  resolved?: string;
+  peer?: boolean;
+  integrity: string;
+  _id: string;
+  extraneous: boolean;
+  path: string;
+  _dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+  peerDependencies: Record<string, string>;
+  dependencies?: NpmMap;
+}
+interface NpmDeps {
+  name: string;
+  main?: string;
+  scripts?: Record<string, string>;
+  extraneous?: boolean;
+  path: string;
+  _dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+  peerDependencies: Record<string, string>;
+  dependencies?: NpmMap;
+}
 
 /**
  * NPM packager.
@@ -29,14 +58,15 @@ export class NPM implements Packager {
     return parseInt(version.split('.')[0]);
   }
 
-  async getProdDependencies(cwd: string, depth?: number) {
+  async getProdDependencies(cwd: string, depth?: number): Promise<DependenciesResult> {
     // Get first level dependency graph
     const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
     const args = [
       'ls',
       '-json',
       '-prod', // Only prod dependencies
-      depth ? `-depth=${depth}` : ((await this.getNpmMajorVersion(cwd)) >= 7) ? '-all' : null,
+      '-long',
+      depth ? `-depth=${depth}` : (await this.getNpmMajorVersion(cwd)) >= 7 ? '-all' : null,
     ].filter(Boolean);
 
     const ignoredNpmErrors = [
@@ -45,11 +75,10 @@ export class NPM implements Packager {
       { npmError: 'peer dep missing', log: true },
     ];
 
+    let parsedDeps: NpmDeps;
     try {
       const processOutput = await spawnProcess(command, args, { cwd });
-      const depJson = processOutput.stdout;
-
-      return JSON.parse(depJson);
+      parsedDeps = JSON.parse(processOutput.stdout) as NpmDeps;
     } catch (err) {
       if (err instanceof SpawnError) {
         // Only exit with an error if we have critical npm errors for 2nd level inside
@@ -62,7 +91,7 @@ export class NPM implements Packager {
             return (
               !isEmpty(error) &&
               !any(
-                ignoredError => startsWith(`npm ERR! ${ignoredError.npmError}`, error),
+                (ignoredError) => startsWith(`npm ERR! ${ignoredError.npmError}`, error),
                 ignoredNpmErrors
               )
             );
@@ -78,6 +107,64 @@ export class NPM implements Packager {
 
       throw err;
     }
+
+    const basePath = parsedDeps.path;
+
+    const convertTrees = (currentTree: NpmMap, rootDeps: DependencyMap): DependencyMap => {
+      return Object.entries(currentTree).reduce<DependencyMap>(
+        (deps, [name, tree]) => {
+          if (tree.path === path.join(basePath, 'node_modules', name)) {
+            // Module path is in the root folder
+
+            // Set it as resolved
+            deps[name] = {
+              version: tree.version,
+              resolved: true,
+            };
+            if (Object.keys(tree._dependencies).length && !tree.dependencies) {
+              // Edge case - When it is de-duped this record will not contain the dependency tree.
+              // We can just ignore storing this at the root because it does not contain the tree we are after
+              // "samchungy-dep-b": {
+              //   "version": "3.0.0",
+              //   "name": "samchungy-dep-b",
+              //   "resolved": "https://registry.npmjs.org/samchungy-dep-b/-/samchungy-dep-b-3.0.0.tgz",
+              //   "integrity": "sha512-fy6RAnofLSnLHgOUmgsFz0ZFnJcJeNHT+qUfHJ7daIFlBaciRDR6v5sdWm7mAM2EzQ1KFf2hmKJVFZgthVeCAw==",
+              //   "_id": "samchungy-dep-b@3.0.0",
+              //   "extraneous": false,
+              //   "path": "/Users/schung/me/serverless-esbuild/examples/individually/node_modules/samchungy-dep-b",
+              //   "_dependencies": {
+              //     "samchungy-dep-c": "^1.0.0",
+              //     "samchungy-dep-d": "^1.0.0"
+              //   },
+              //   "devDependencies": {},
+              //   "peerDependencies": {}
+              // }
+            } else {
+              // This is a root node_modules dependency. When rootDeps = deps, this will just overwrite the resolved declaration above
+              rootDeps[name] = {
+                version: tree.version,
+                ...(tree.dependencies && {
+                  dependencies: convertTrees(tree.dependencies, rootDeps),
+                }),
+              };
+            }
+            return deps;
+          }
+
+          // Module is only installed within the node_modules of this dep. Iterate through it's dep tree
+          deps[name] = {
+            version: tree.version,
+            ...(tree.dependencies && { dependencies: convertTrees(tree.dependencies, rootDeps) }),
+          };
+          return deps;
+        },
+        !Object.keys(rootDeps).length ? rootDeps : {} // Only use rootDeps if it is empty
+      );
+    };
+
+    return {
+      dependencies: convertTrees(parsedDeps.dependencies, {}),
+    };
   }
 
   _rebaseFileReferences(pathToPackageRoot: string, moduleVersion: string) {
@@ -128,7 +215,7 @@ export class NPM implements Packager {
     const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
 
     await Promise.all(
-      scriptNames.map(scriptName => {
+      scriptNames.map((scriptName) => {
         const args = ['run', scriptName];
 
         return spawnProcess(command, args, { cwd });

--- a/src/packagers/npm.ts
+++ b/src/packagers/npm.ts
@@ -16,27 +16,28 @@ export interface NpmTree {
   _id: string;
   extraneous: boolean;
   path: string;
-  _dependencies: Record<string, string>;
-  devDependencies: Record<string, string>;
+  _dependencies: Record<string, string> | string;
+  devDependencies: Record<string, string> | string;
   peerDependencies?: Record<string, string>;
   dependencies?: NpmMap;
-  _args?: string[][];
+  _args?: string[][] | string;
   _from?: string;
   _integrity?: string;
   _location?: string;
-  _phantomChildren?: Record<string, unknown>;
+  _phantomChildren?: Record<string, unknown> | string;
   _requested?: Record<string, unknown>;
-  _requiredBy?: string[];
+  _requiredBy?: string[] | string;
   _resolved?: string;
   _spec?: string;
   _where?: string;
   author?: string;
   license?: string;
   main?: string;
-  scripts?: Record<string, string>;
+  scripts?: Record<string, string> | string;
   readme?: string;
-  optionalDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string> | string;
   error?: string | Error;
+  _deduped?: string;
 }
 export interface NpmDeps {
   name: string;
@@ -104,7 +105,6 @@ export class NPM implements Packager {
     try {
       const processOutput = await spawnProcess(command, args, { cwd });
       parsedDeps = JSON.parse(processOutput.stdout) as NpmDeps;
-      console.log(processOutput.stdout);
     } catch (err) {
       if (err instanceof SpawnError) {
         // Only exit with an error if we have critical npm errors for 2nd level inside
@@ -147,8 +147,9 @@ export class NPM implements Packager {
               version: tree.version,
               isRootDep: true,
             };
-            if (Object.keys(tree._dependencies).length && !tree.dependencies) {
+            if (tree._deduped || (Object.keys(tree._dependencies).length && !tree.dependencies)) {
               // Edge case - When it is de-duped this record will not contain the dependency tree.
+              // _deduped is for v6 (Object.keys(tree._dependencies).length && !tree.dependencies) for v7
               // We can just ignore storing this at the root because it does not contain the tree we are after
               // "samchungy-dep-b": {
               //   "version": "3.0.0",

--- a/src/packagers/npm.ts
+++ b/src/packagers/npm.ts
@@ -158,7 +158,7 @@ export class NPM implements Packager {
           };
           return deps;
         },
-        !Object.keys(rootDeps).length ? rootDeps : {} // Only use rootDeps if it is empty
+        !Object.keys(rootDeps).length ? rootDeps : {} // Only use rootDeps if it is empty (first iteration only)
       );
     };
 

--- a/src/packagers/packager.ts
+++ b/src/packagers/packager.ts
@@ -1,10 +1,10 @@
-import { JSONObject } from '../types';
+import { DependenciesResult, JSONObject } from '../types';
 
 export interface Packager {
   lockfileName: string;
   copyPackageSectionNames: Array<string>;
   mustCopyModules: boolean;
-  getProdDependencies(cwd: string, depth?: number): Promise<JSONObject>;
+  getProdDependencies(cwd: string, depth?: number): Promise<DependenciesResult>;
   rebaseLockfile(pathToPackageRoot: string, lockfile: JSONObject): JSONObject;
   install(cwd: string, extraArgs: Array<string>, useLockfile?: boolean): Promise<void>;
   prune(cwd: string): Promise<void>;

--- a/src/packagers/yarn.ts
+++ b/src/packagers/yarn.ts
@@ -131,7 +131,7 @@ export class Yarn implements Packager {
             // }
             deps[name] = {
               version,
-              resolved: true,
+              isRootDep: true,
             };
           } else {
             // Package info is in anther child so we can just ignore

--- a/src/packagers/yarn.ts
+++ b/src/packagers/yarn.ts
@@ -112,17 +112,17 @@ export class Yarn implements Packager {
           if (satisfies(rootDependencies[name].version, version)) {
             // Package is at root level
             // {
-            //   "name": "samchungy-dep-a@1.0.0",
+            //   "name": "samchungy-dep-a@1.0.0", <- MATCH
             //   "children": [],
             //   "hint": null,
             //   "color": null,
             //   "depth": 0
             // },
             // {
-            //   "name": "samchungy-a@2.0.1",
+            //   "name": "samchungy-a@2.0.0",
             //   "children": [
             //     {
-            //       "name": "samchungy-dep-a@1.0.0",
+            //       "name": "samchungy-dep-a@1.0.0", <- THIS
             //       "color": "dim",
             //       "shadow": true
             //     }
@@ -137,12 +137,12 @@ export class Yarn implements Packager {
             };
           } else {
             // Package info is in anther child so we can just ignore
-            // dep samchungy-dep-a@1.0.0 is in the root
+            // samchungy-dep-a@1.0.0 is in the root (see above example)
             // {
             //   "name": "samchungy-b@2.0.0",
             //   "children": [
             //     {
-            //       "name": "samchungy-dep-a@2.0.0",
+            //       "name": "samchungy-dep-a@2.0.0", <- THIS
             //       "color": "dim",
             //       "shadow": true
             //     },
@@ -163,6 +163,13 @@ export class Yarn implements Packager {
         }
 
         // Package is not defined, store it and get the children
+        //     {
+        //       "name": "samchungy-dep-a@2.0.0",
+        //       "children": [],
+        //       "hint": null,
+        //       "color": "bold",
+        //       "depth": 0
+        //     }
         deps[name] = {
           version,
           ...(tree?.children?.length && { dependencies: convertTrees(tree.children) }),

--- a/src/packagers/yarn.ts
+++ b/src/packagers/yarn.ts
@@ -13,7 +13,7 @@ interface YarnTree {
   depth?: number;
   shadow?: boolean;
 }
-interface YarnDeps {
+export interface YarnDeps {
   type: 'tree';
   data: {
     type: 'list';
@@ -92,8 +92,10 @@ export class Yarn implements Packager {
       throw err;
     }
 
+    const rootTree = parsedDeps.data.trees;
+
     // Produces a version map for the modules present in our root node_modules folder
-    const rootDependencies = parsedDeps.data.trees.reduce<DependencyMap>((deps, tree) => {
+    const rootDependencies = rootTree.reduce<DependencyMap>((deps, tree) => {
       const { name, version } = getNameAndVersion(tree.name);
       deps[name] = {
         version: version,
@@ -177,7 +179,7 @@ export class Yarn implements Packager {
     };
 
     return {
-      dependencies: convertTrees(parsedDeps.data.trees),
+      dependencies: convertTrees(rootTree),
     };
   }
 

--- a/src/packagers/yarn.ts
+++ b/src/packagers/yarn.ts
@@ -97,7 +97,7 @@ export class Yarn implements Packager {
     // Produces a version map for the modules present in our root node_modules folder
     const rootDependencies = rootTree.reduce<DependencyMap>((deps, tree) => {
       const { name, version } = getNameAndVersion(tree.name);
-      deps[name] = {
+      deps[name] ??= {
         version: version,
       };
       return deps;
@@ -131,7 +131,7 @@ export class Yarn implements Packager {
             //   "color": "bold",
             //   "depth": 0
             // }
-            deps[name] = {
+            deps[name] ??= {
               version,
               isRootDep: true,
             };
@@ -170,7 +170,7 @@ export class Yarn implements Packager {
         //       "color": "bold",
         //       "depth": 0
         //     }
-        deps[name] = {
+        deps[name] ??= {
           version,
           ...(tree?.children?.length && { dependencies: convertTrees(tree.children) }),
         };

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import { mocked } from 'ts-jest/utils';
 
 import { extractFileNames, flatDep } from '../helper';
+import { DependencyMap } from '../types';
 
 jest.mock('fs-extra');
 
@@ -148,7 +149,7 @@ describe('extractFileNames', () => {
 describe('flatDeps', () => {
   describe('basic', () => {
     it('should pull all the dependencies from samchungy-a and samchungy-b', () => {
-      const DependencyMap = {
+      const depMap: DependencyMap = {
         'samchungy-a': {
           dependencies: {
             'samchungy-dep-a': {
@@ -173,13 +174,13 @@ describe('flatDeps', () => {
 
       const expectedResult: string[] = ['samchungy-a', 'samchungy-dep-a', 'samchungy-b'];
 
-      const result = flatDep(DependencyMap, ['samchungy-a', 'samchungy-b']);
+      const result = flatDep(depMap, ['samchungy-a', 'samchungy-b']);
 
       expect(result).toStrictEqual(expectedResult);
     });
 
     it('should pull only the dependencies of samchungy-b', () => {
-      const DependencyMap = {
+      const depMap: DependencyMap = {
         'samchungy-a': {
           dependencies: {
             'samchungy-dep-a': {
@@ -204,7 +205,7 @@ describe('flatDeps', () => {
 
       const expectedResult: string[] = ['samchungy-b'];
 
-      const result = flatDep(DependencyMap, ['samchungy-b']);
+      const result = flatDep(depMap, ['samchungy-b']);
 
       expect(result).toStrictEqual(expectedResult);
     });
@@ -212,7 +213,7 @@ describe('flatDeps', () => {
 
   describe('deduped', () => {
     it('should pull all the dependencies from samchungy-a and samchungy-b', () => {
-      const DependencyMap = {
+      const depMap: DependencyMap = {
         'samchungy-a': {
           version: '3.0.0',
           dependencies: {
@@ -256,13 +257,13 @@ describe('flatDeps', () => {
         'samchungy-b',
       ];
 
-      const result = flatDep(DependencyMap, ['samchungy-a', 'samchungy-b']);
+      const result = flatDep(depMap, ['samchungy-a', 'samchungy-b']);
 
       expect(result).toStrictEqual(expectedResult);
     });
 
     it('should pull only the dependencies from samchungy-a', () => {
-      const DependencyMap = {
+      const depMap: DependencyMap = {
         'samchungy-a': {
           version: '3.0.0',
           dependencies: {
@@ -306,7 +307,7 @@ describe('flatDeps', () => {
         'samchungy-b',
       ];
 
-      const result = flatDep(DependencyMap, ['samchungy-a', 'samchungy-b']);
+      const result = flatDep(depMap, ['samchungy-a', 'samchungy-b']);
 
       expect(result).toStrictEqual(expectedResult);
     });

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -172,7 +172,7 @@ describe('flatDeps', () => {
         },
       };
 
-      const expectedResult: string[] = ['samchungy-a', 'samchungy-dep-a', 'samchungy-b'];
+      const expectedResult: string[] = ['samchungy-dep-a', 'samchungy-a', 'samchungy-b'];
 
       const result = flatDep(depMap, ['samchungy-a', 'samchungy-b']);
 
@@ -249,11 +249,11 @@ describe('flatDeps', () => {
       };
 
       const expectedResult: string[] = [
-        'samchungy-a',
-        'samchungy-dep-b',
-        'samchungy-dep-c',
         'samchungy-dep-e',
+        'samchungy-dep-c',
         'samchungy-dep-d',
+        'samchungy-dep-b',
+        'samchungy-a',
         'samchungy-b',
       ];
 
@@ -299,11 +299,11 @@ describe('flatDeps', () => {
       };
 
       const expectedResult: string[] = [
-        'samchungy-a',
-        'samchungy-dep-b',
-        'samchungy-dep-c',
         'samchungy-dep-e',
+        'samchungy-dep-c',
         'samchungy-dep-d',
+        'samchungy-dep-b',
+        'samchungy-a',
         'samchungy-b',
       ];
 

--- a/src/tests/packagers/npm.test.ts
+++ b/src/tests/packagers/npm.test.ts
@@ -430,14 +430,8 @@ describe('NPM Packager', () => {
       dependencies: {
         'samchungy-a': {
           _args: [
-            [
-              'samchungy-a@3.0.0',
-              '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-            ],
-            [
-              'samchungy-a@3.0.0',
-              '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-            ],
+            ['samchungy-a@3.0.0', '/workdir/.esbuild/.build'],
+            ['samchungy-a@3.0.0', '/workdir/.esbuild/.build'],
           ],
           _from: 'samchungy-a@3.0.0',
           _id: 'samchungy-a@3.0.0',
@@ -458,19 +452,13 @@ describe('NPM Packager', () => {
           _requiredBy: ['/'],
           _resolved: 'https://registry.npmjs.org/samchungy-a/-/samchungy-a-3.0.0.tgz',
           _spec: '3.0.0',
-          _where: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
+          _where: '/workdir/.esbuild/.build',
           author: '',
           dependencies: {
             'samchungy-dep-b': {
               _args: [
-                [
-                  'samchungy-dep-b@3.0.0',
-                  '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-                ],
-                [
-                  'samchungy-dep-b@3.0.0',
-                  '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-                ],
+                ['samchungy-dep-b@3.0.0', '/workdir/.esbuild/.build'],
+                ['samchungy-dep-b@3.0.0', '/workdir/.esbuild/.build'],
               ],
               _from: 'samchungy-dep-b@3.0.0',
               _id: 'samchungy-dep-b@3.0.0',
@@ -491,19 +479,13 @@ describe('NPM Packager', () => {
               _requiredBy: ['/samchungy-a', '/samchungy-b'],
               _resolved: 'https://registry.npmjs.org/samchungy-dep-b/-/samchungy-dep-b-3.0.0.tgz',
               _spec: '3.0.0',
-              _where: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
+              _where: '/workdir/.esbuild/.build',
               author: '',
               dependencies: {
                 'samchungy-dep-c': {
                   _args: [
-                    [
-                      'samchungy-dep-c@1.0.0',
-                      '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-                    ],
-                    [
-                      'samchungy-dep-c@1.0.0',
-                      '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-                    ],
+                    ['samchungy-dep-c@1.0.0', '/workdir/.esbuild/.build'],
+                    ['samchungy-dep-c@1.0.0', '/workdir/.esbuild/.build'],
                   ],
                   _from: 'samchungy-dep-c@1.0.0',
                   _id: 'samchungy-dep-c@1.0.0',
@@ -525,20 +507,13 @@ describe('NPM Packager', () => {
                   _resolved:
                     'https://registry.npmjs.org/samchungy-dep-c/-/samchungy-dep-c-1.0.0.tgz',
                   _spec: '1.0.0',
-                  _where:
-                    '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
+                  _where: '/workdir/.esbuild/.build',
                   author: '',
                   dependencies: {
                     'samchungy-dep-e': {
                       _args: [
-                        [
-                          'samchungy-dep-e@1.0.0',
-                          '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-                        ],
-                        [
-                          'samchungy-dep-e@1.0.0',
-                          '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-                        ],
+                        ['samchungy-dep-e@1.0.0', '/workdir/.esbuild/.build'],
+                        ['samchungy-dep-e@1.0.0', '/workdir/.esbuild/.build'],
                       ],
                       _from: 'samchungy-dep-e@1.0.0',
                       _id: 'samchungy-dep-e@1.0.0',
@@ -560,8 +535,7 @@ describe('NPM Packager', () => {
                       _resolved:
                         'https://registry.npmjs.org/samchungy-dep-e/-/samchungy-dep-e-1.0.0.tgz',
                       _spec: '1.0.0',
-                      _where:
-                        '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
+                      _where: '/workdir/.esbuild/.build',
                       author: '',
                       license: 'ISC',
                       main: 'index.js',
@@ -573,7 +547,7 @@ describe('NPM Packager', () => {
                       devDependencies: {},
                       optionalDependencies: {},
                       _dependencies: {},
-                      path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-e',
+                      path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-e',
                       error: '[Circular]',
                       extraneous: false,
                     },
@@ -587,20 +561,14 @@ describe('NPM Packager', () => {
                   devDependencies: {},
                   optionalDependencies: {},
                   _dependencies: { 'samchungy-dep-e': '^1.0.0' },
-                  path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-c',
+                  path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-c',
                   error: '[Circular]',
                   extraneous: false,
                 },
                 'samchungy-dep-d': {
                   _args: [
-                    [
-                      'samchungy-dep-d@1.0.0',
-                      '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-                    ],
-                    [
-                      'samchungy-dep-d@1.0.0',
-                      '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-                    ],
+                    ['samchungy-dep-d@1.0.0', '/workdir/.esbuild/.build'],
+                    ['samchungy-dep-d@1.0.0', '/workdir/.esbuild/.build'],
                   ],
                   _from: 'samchungy-dep-d@1.0.0',
                   _id: 'samchungy-dep-d@1.0.0',
@@ -622,8 +590,7 @@ describe('NPM Packager', () => {
                   _resolved:
                     'https://registry.npmjs.org/samchungy-dep-d/-/samchungy-dep-d-1.0.0.tgz',
                   _spec: '1.0.0',
-                  _where:
-                    '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
+                  _where: '/workdir/.esbuild/.build',
                   author: '',
                   dependencies: {
                     'samchungy-dep-e': {
@@ -648,8 +615,7 @@ describe('NPM Packager', () => {
                       _resolved:
                         'https://registry.npmjs.org/samchungy-dep-e/-/samchungy-dep-e-1.0.0.tgz',
                       _spec: '1.0.0',
-                      _where:
-                        '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
+                      _where: '/workdir/.esbuild/.build',
                       author: '',
                       license: 'ISC',
                       main: 'index.js',
@@ -661,7 +627,7 @@ describe('NPM Packager', () => {
                       devDependencies: '[Circular]',
                       optionalDependencies: '[Circular]',
                       _dependencies: '[Circular]',
-                      path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-e',
+                      path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-e',
                       error: '[Circular]',
                       extraneous: false,
                       _deduped: 'samchungy-dep-e',
@@ -676,7 +642,7 @@ describe('NPM Packager', () => {
                   devDependencies: {},
                   optionalDependencies: {},
                   _dependencies: { 'samchungy-dep-e': '^1.0.0' },
-                  path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-d',
+                  path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-d',
                   error: '[Circular]',
                   extraneous: false,
                 },
@@ -690,7 +656,7 @@ describe('NPM Packager', () => {
               devDependencies: {},
               optionalDependencies: {},
               _dependencies: { 'samchungy-dep-c': '^1.0.0', 'samchungy-dep-d': '^1.0.0' },
-              path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-b',
+              path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-b',
               error: '[Circular]',
               extraneous: false,
             },
@@ -704,20 +670,14 @@ describe('NPM Packager', () => {
           devDependencies: {},
           optionalDependencies: {},
           _dependencies: { 'samchungy-dep-b': '3.0.0' },
-          path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-a',
+          path: '/workdir/.esbuild/.build/node_modules/samchungy-a',
           error: '[Circular]',
           extraneous: false,
         },
         'samchungy-b': {
           _args: [
-            [
-              'samchungy-b@5.0.0',
-              '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-            ],
-            [
-              'samchungy-b@5.0.0',
-              '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
-            ],
+            ['samchungy-b@5.0.0', '/workdir/.esbuild/.build'],
+            ['samchungy-b@5.0.0', '/workdir/.esbuild/.build'],
           ],
           _from: 'samchungy-b@5.0.0',
           _id: 'samchungy-b@5.0.0',
@@ -738,7 +698,7 @@ describe('NPM Packager', () => {
           _requiredBy: ['/'],
           _resolved: 'https://registry.npmjs.org/samchungy-b/-/samchungy-b-5.0.0.tgz',
           _spec: '5.0.0',
-          _where: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
+          _where: '/workdir/.esbuild/.build',
           author: '',
           dependencies: {
             'samchungy-dep-b': {
@@ -762,7 +722,7 @@ describe('NPM Packager', () => {
               _requiredBy: '[Circular]',
               _resolved: 'https://registry.npmjs.org/samchungy-dep-b/-/samchungy-dep-b-3.0.0.tgz',
               _spec: '3.0.0',
-              _where: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
+              _where: '/workdir/.esbuild/.build',
               author: '',
               dependencies: {},
               license: 'ISC',
@@ -774,7 +734,7 @@ describe('NPM Packager', () => {
               devDependencies: '[Circular]',
               optionalDependencies: '[Circular]',
               _dependencies: '[Circular]',
-              path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-b',
+              path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-b',
               error: '[Circular]',
               extraneous: false,
               _deduped: 'samchungy-dep-b',
@@ -789,7 +749,7 @@ describe('NPM Packager', () => {
           devDependencies: {},
           optionalDependencies: {},
           _dependencies: { 'samchungy-dep-b': '3.0.0' },
-          path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-b',
+          path: '/workdir/.esbuild/.build/node_modules/samchungy-b',
           error: '[Circular]',
           extraneous: false,
         },
@@ -848,7 +808,7 @@ describe('NPM Packager', () => {
       devDependencies: {},
       optionalDependencies: {},
       _dependencies: { 'samchungy-a': '3.0.0', 'samchungy-b': '5.0.0' },
-      path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
+      path: '/workdir/.esbuild/.build',
       error: '[Circular]',
       extraneous: false,
     };
@@ -861,7 +821,7 @@ describe('NPM Packager', () => {
       scripts: {},
       _id: 'serverless-example@1.0.0',
       extraneous: false,
-      path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build',
+      path: '/workdir/.esbuild/.build',
       _dependencies: { 'samchungy-a': '3.0.0', 'samchungy-b': '5.0.0' },
       devDependencies: {},
       peerDependencies: {},
@@ -874,7 +834,7 @@ describe('NPM Packager', () => {
             'sha512-5u55rgjPpASgPDU2jLYf4HCt31jUVtzy/r42q4SyJ4W+ItggEk+8w3WBfXRcQgxYyyWflL1F9w85u3Wudj542g==',
           _id: 'samchungy-a@3.0.0',
           extraneous: false,
-          path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-a',
+          path: '/workdir/.esbuild/.build/node_modules/samchungy-a',
           _dependencies: { 'samchungy-dep-b': '3.0.0' },
           devDependencies: {},
           peerDependencies: {},
@@ -887,7 +847,7 @@ describe('NPM Packager', () => {
                 'sha512-fy6RAnofLSnLHgOUmgsFz0ZFnJcJeNHT+qUfHJ7daIFlBaciRDR6v5sdWm7mAM2EzQ1KFf2hmKJVFZgthVeCAw==',
               _id: 'samchungy-dep-b@3.0.0',
               extraneous: false,
-              path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-b',
+              path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-b',
               _dependencies: {
                 'samchungy-dep-c': '^1.0.0',
                 'samchungy-dep-d': '^1.0.0',
@@ -904,7 +864,7 @@ describe('NPM Packager', () => {
                     'sha512-YMLl+vnxi7kNr59zq+FFVfBBKyPyxqc7LUU92ZYTkTJaEGHNlCyC2fVC+diIVaomhn4CNAqmOGIVqbr5sq8lQg==',
                   _id: 'samchungy-dep-c@1.0.0',
                   extraneous: false,
-                  path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-c',
+                  path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-c',
                   _dependencies: { 'samchungy-dep-e': '^1.0.0' },
                   devDependencies: {},
                   peerDependencies: {},
@@ -918,7 +878,7 @@ describe('NPM Packager', () => {
                         'sha512-phnrKKAOuZdVrVk86R6CNU62YC4bRr/Ru1SokC5ZqkXh4QR30XU4ApSTuLbFADb6F3HWKZTGelaoklyMW2mveg==',
                       _id: 'samchungy-dep-e@1.0.0',
                       extraneous: false,
-                      path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-e',
+                      path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-e',
                       _dependencies: {},
                       devDependencies: {},
                       peerDependencies: {},
@@ -934,7 +894,7 @@ describe('NPM Packager', () => {
                     'sha512-yxXY2+OVhx1e5QZWSWrCajs5b2FCD0CV2ztss+7x4IgQbM0u5gMfzva31kMZFzX2iLJ7iy+09DYpe34TSRrzsA==',
                   _id: 'samchungy-dep-d@1.0.0',
                   extraneous: false,
-                  path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-d',
+                  path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-d',
                   _dependencies: { 'samchungy-dep-e': '^1.0.0' },
                   devDependencies: {},
                   peerDependencies: {},
@@ -948,7 +908,7 @@ describe('NPM Packager', () => {
                         'sha512-phnrKKAOuZdVrVk86R6CNU62YC4bRr/Ru1SokC5ZqkXh4QR30XU4ApSTuLbFADb6F3HWKZTGelaoklyMW2mveg==',
                       _id: 'samchungy-dep-e@1.0.0',
                       extraneous: false,
-                      path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-e',
+                      path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-e',
                       _dependencies: {},
                       devDependencies: {},
                       peerDependencies: {},
@@ -967,7 +927,7 @@ describe('NPM Packager', () => {
             'sha512-Swb34L5tb1agVosN97lXr+HzMzYXvwt2XuZAe9YGVzAWYduObaS5Rc0lwYUkILqKmwqLmtb29Jc2veiNAmU2zw==',
           _id: 'samchungy-b@5.0.0',
           extraneous: false,
-          path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-b',
+          path: '/workdir/.esbuild/.build/node_modules/samchungy-b',
           _dependencies: { 'samchungy-dep-b': '3.0.0' },
           devDependencies: {},
           peerDependencies: {},
@@ -980,7 +940,7 @@ describe('NPM Packager', () => {
                 'sha512-fy6RAnofLSnLHgOUmgsFz0ZFnJcJeNHT+qUfHJ7daIFlBaciRDR6v5sdWm7mAM2EzQ1KFf2hmKJVFZgthVeCAw==',
               _id: 'samchungy-dep-b@3.0.0',
               extraneous: false,
-              path: '/Users/schung/me/serverless-esbuild/examples/individually/.esbuild/.build/node_modules/samchungy-dep-b',
+              path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-b',
               _dependencies: {
                 'samchungy-dep-c': '^1.0.0',
                 'samchungy-dep-d': '^1.0.0',

--- a/src/tests/packagers/npm.test.ts
+++ b/src/tests/packagers/npm.test.ts
@@ -1,4 +1,4 @@
-import { NPM, NpmDeps } from '../../packagers/npm';
+import { NPM, NpmV6Deps, NpmV7Deps } from '../../packagers/npm';
 import { DependenciesResult } from '../../types';
 
 import * as utils from '../../utils';
@@ -66,7 +66,7 @@ describe('NPM Packager', () => {
   });
 
   it('should create the same dependency tree from npm v6 and npm v7 output', async () => {
-    const v6depsList: NpmDeps = {
+    const v6depsList: NpmV6Deps = {
       name: 'serverless-example',
       version: '1.0.0',
       description: 'Packaged externals for serverless-example',
@@ -301,7 +301,7 @@ describe('NPM Packager', () => {
       extraneous: false,
     };
 
-    const v7depsList: NpmDeps = {
+    const v7depsList: NpmV7Deps = {
       version: '1.0.0',
       name: 'serverless-example',
       description: 'Packaged externals for serverless-example',
@@ -421,7 +421,7 @@ describe('NPM Packager', () => {
   });
 
   it('should create the same dependency tree which handles deduping for both npmv6 and npmv7', async () => {
-    const v6depsList: NpmDeps = {
+    const v6depsList: NpmV6Deps = {
       name: 'serverless-example',
       version: '1.0.0',
       description: 'Packaged externals for serverless-example',
@@ -813,7 +813,7 @@ describe('NPM Packager', () => {
       extraneous: false,
     };
 
-    const v7depsList: NpmDeps = {
+    const v7depsList: NpmV7Deps = {
       version: '1.0.0',
       name: 'serverless-example',
       description: 'Packaged externals for serverless-example',

--- a/src/tests/packagers/npm.test.ts
+++ b/src/tests/packagers/npm.test.ts
@@ -16,11 +16,11 @@ describe('test NPM class', () => {
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'));
-    
+
     expect(spawnSpy.calls.length).toStrictEqual(2);
     expect(spawnSpy.calls[0].args).toStrictEqual(['--version']);
-    expect(spawnSpy.calls[1].args).toStrictEqual(['ls', '-json', '-prod']);
-    expect(dependencies).toStrictEqual({'dependencies':{}});
+    expect(spawnSpy.calls[1].args).toStrictEqual(['ls', '-json', '-prod', '-long']);
+    expect(dependencies).toStrictEqual({ dependencies: {} });
   });
 
   it('should properly get the dependencies list w/ depth', async () => {
@@ -28,10 +28,10 @@ describe('test NPM class', () => {
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'), 2);
-    
+
     expect(spawnSpy.calls.length).toStrictEqual(1);
-    expect(spawnSpy.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-depth=2']);
-    expect(dependencies).toStrictEqual({'dependencies':{}});
+    expect(spawnSpy.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-long', '-depth=2']);
+    expect(dependencies).toStrictEqual({ dependencies: {} });
   });
 
   it('should properly get the dependencies list (npm version >= 7)', async () => {
@@ -40,11 +40,11 @@ describe('test NPM class', () => {
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'));
-    
+
     expect(spawnSpy.calls.length).toStrictEqual(2);
     expect(spawnSpy.calls[0].args).toStrictEqual(['--version']);
-    expect(spawnSpy.calls[1].args).toStrictEqual(['ls', '-json', '-prod', '-all']);
-    expect(dependencies).toStrictEqual({'dependencies':{}});
+    expect(spawnSpy.calls[1].args).toStrictEqual(['ls', '-json', '-prod', '-long', '-all']);
+    expect(dependencies).toStrictEqual({ dependencies: {} });
   });
 
   it('should properly get the dependencies list w/ depth (npm version >= 7)', async () => {
@@ -52,9 +52,9 @@ describe('test NPM class', () => {
 
     const npm = new NPM();
     const dependencies = await npm.getProdDependencies(path.join('./'), 2);
-    
+
     expect(spawnSpy.calls.length).toStrictEqual(1);
-    expect(spawnSpy.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-depth=2']);
-    expect(dependencies).toStrictEqual({'dependencies':{}});
+    expect(spawnSpy.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-long', '-depth=2']);
+    expect(dependencies).toStrictEqual({ dependencies: {} });
   });
 });

--- a/src/tests/packagers/npm.test.ts
+++ b/src/tests/packagers/npm.test.ts
@@ -1,60 +1,442 @@
-import { NPM } from '../../packagers/npm';
-import * as path from 'path';
-import * as mockSpawn from 'mock-spawn';
+import { NPM, NpmDeps } from '../../packagers/npm';
 
-describe('test NPM class', () => {
-  let spawnSpy = mockSpawn();
+import * as utils from '../../utils';
+
+jest.mock('process');
+describe('NPM Packager', () => {
+  const npm = new NPM();
+  const path = './';
+
+  let spawnSpy = jest.spyOn(utils, 'spawnProcess');
 
   beforeEach(() => {
-    spawnSpy = mockSpawn();
-    require('child_process').spawn = spawnSpy;
+    spawnSpy = jest.spyOn(utils, 'spawnProcess');
   });
 
-  it('should properly get the dependencies list', async () => {
-    spawnSpy.sequence.add(spawnSpy.simple(0, '6.0.0'));
-    spawnSpy.sequence.add(spawnSpy.simple(0, '{"dependencies":{}}'));
-
-    const npm = new NPM();
-    const dependencies = await npm.getProdDependencies(path.join('./'));
-
-    expect(spawnSpy.calls.length).toStrictEqual(2);
-    expect(spawnSpy.calls[0].args).toStrictEqual(['--version']);
-    expect(spawnSpy.calls[1].args).toStrictEqual(['ls', '-json', '-prod', '-long']);
-    expect(dependencies).toStrictEqual({ dependencies: {} });
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 
-  it('should properly get the dependencies list w/ depth', async () => {
-    spawnSpy.sequence.add(spawnSpy.simple(0, '{"dependencies":{}}'));
+  it('should call spawnProcess with the correct arguments for getting the npm version', async () => {
+    spawnSpy
+      .mockResolvedValueOnce({ stderr: '', stdout: '6.0.0' })
+      .mockResolvedValueOnce({ stderr: '', stdout: '{"dependencies":{}}' });
 
-    const npm = new NPM();
-    const dependencies = await npm.getProdDependencies(path.join('./'), 2);
+    await npm.getProdDependencies(path);
 
-    expect(spawnSpy.calls.length).toStrictEqual(1);
-    expect(spawnSpy.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-long', '-depth=2']);
-    expect(dependencies).toStrictEqual({ dependencies: {} });
+    expect(spawnSpy).toBeCalledTimes(2);
+    expect(spawnSpy).toBeCalledWith('npm', ['--version'], { cwd: './' });
   });
 
-  it('should properly get the dependencies list (npm version >= 7)', async () => {
-    spawnSpy.sequence.add(spawnSpy.simple(0, '7.0.0'));
-    spawnSpy.sequence.add(spawnSpy.simple(0, '{"dependencies":{}}'));
+  it('should call spawnProcess with the correct arguments for listing dependencies on npm', async () => {
+    spawnSpy
+      .mockResolvedValueOnce({ stderr: '', stdout: '6.0.0' })
+      .mockResolvedValueOnce({ stderr: '', stdout: '{"dependencies":{}}' });
 
-    const npm = new NPM();
-    const dependencies = await npm.getProdDependencies(path.join('./'));
+    await npm.getProdDependencies(path);
 
-    expect(spawnSpy.calls.length).toStrictEqual(2);
-    expect(spawnSpy.calls[0].args).toStrictEqual(['--version']);
-    expect(spawnSpy.calls[1].args).toStrictEqual(['ls', '-json', '-prod', '-long', '-all']);
-    expect(dependencies).toStrictEqual({ dependencies: {} });
+    expect(spawnSpy).toBeCalledTimes(2);
+    expect(spawnSpy).toBeCalledWith('npm', ['ls', '-json', '-prod', '-long'], { cwd: './' });
   });
 
-  it('should properly get the dependencies list w/ depth (npm version >= 7)', async () => {
-    spawnSpy.sequence.add(spawnSpy.simple(0, '{"dependencies":{}}'));
+  it('should call spawnProcess with the correct arguments for listing dependencies on npm v7', async () => {
+    spawnSpy
+      .mockResolvedValueOnce({ stderr: '', stdout: '7.0.0' })
+      .mockResolvedValueOnce({ stderr: '', stdout: '{"dependencies":{}}' });
 
-    const npm = new NPM();
-    const dependencies = await npm.getProdDependencies(path.join('./'), 2);
+    await npm.getProdDependencies(path);
 
-    expect(spawnSpy.calls.length).toStrictEqual(1);
-    expect(spawnSpy.calls[0].args).toStrictEqual(['ls', '-json', '-prod', '-long', '-depth=2']);
-    expect(dependencies).toStrictEqual({ dependencies: {} });
+    expect(spawnSpy).toBeCalledTimes(2);
+    expect(spawnSpy).toBeCalledWith('npm', ['ls', '-json', '-prod', '-long', '-all'], {
+      cwd: './',
+    });
+  });
+
+  it('should call spawnProcess with the correct arguments for listing dependencies when depth is provided', async () => {
+    spawnSpy.mockResolvedValueOnce({ stderr: '', stdout: '{"dependencies":{}}' });
+
+    await npm.getProdDependencies(path, 2);
+
+    expect(spawnSpy).toBeCalledTimes(1);
+    expect(spawnSpy).toBeCalledWith('npm', ['ls', '-json', '-prod', '-long', '-depth=2'], {
+      cwd: './',
+    });
+  });
+
+  it('should create a dependency tree from npm v6 output', async () => {
+    const depsList: NpmDeps = {
+      name: 'serverless-example',
+      version: '1.0.0',
+      description: 'Packaged externals for serverless-example',
+      private: true,
+      scripts: {},
+      dependencies: {
+        'samchungy-a': {
+          _args: [
+            ['samchungy-a@2.0.0', '/workdir/.esbuild/.build'],
+            ['samchungy-a@2.0.0', '/workdir/.esbuild/.build'],
+          ],
+          _from: 'samchungy-a@2.0.0',
+          _id: 'samchungy-a@2.0.0',
+          _integrity:
+            'sha512-gUv/cvd9AFYvvGep0e9m1wSAf3dfnb71eri5TjtgC6N7qvJALXFaFVOkLNBHEYGEm2ZJdosXvGqr3ISZ7Yh46Q==',
+          _location: '/samchungy-a',
+          _phantomChildren: {},
+          _requested: {
+            type: 'version',
+            registry: true,
+            raw: 'samchungy-a@2.0.0',
+            name: 'samchungy-a',
+            escapedName: 'samchungy-a',
+            rawSpec: '2.0.0',
+            saveSpec: null,
+            fetchSpec: '2.0.0',
+          },
+          _requiredBy: ['/'],
+          _resolved: 'https://registry.npmjs.org/samchungy-a/-/samchungy-a-2.0.0.tgz',
+          _spec: '2.0.0',
+          _where: '/workdir/.esbuild/.build',
+          author: '',
+          dependencies: {
+            'samchungy-dep-a': {
+              _args: [
+                ['samchungy-dep-a@1.0.0', '/workdir/.esbuild/.build'],
+                ['samchungy-dep-a@1.0.0', '/workdir/.esbuild/.build'],
+              ],
+              _from: 'samchungy-dep-a@1.0.0',
+              _id: 'samchungy-dep-a@1.0.0',
+              _integrity:
+                'sha512-NVac5aAU+p7bsIrUTQO438vAO8MHyNILbeckhzxhadIUqGx3L9kEZ5HTqZ+XqDIRARmOU6UmFtus6Bc7q5+mWA==',
+              _location: '/samchungy-dep-a',
+              _phantomChildren: {},
+              _requested: {
+                type: 'version',
+                registry: true,
+                raw: 'samchungy-dep-a@1.0.0',
+                name: 'samchungy-dep-a',
+                escapedName: 'samchungy-dep-a',
+                rawSpec: '1.0.0',
+                saveSpec: '[Circular]',
+                fetchSpec: '1.0.0',
+              },
+              _requiredBy: ['/samchungy-a'],
+              _resolved: 'https://registry.npmjs.org/samchungy-dep-a/-/samchungy-dep-a-1.0.0.tgz',
+              _spec: '1.0.0',
+              _where: '/workdir/.esbuild/.build',
+              author: '',
+              license: 'ISC',
+              main: 'index.js',
+              name: 'samchungy-dep-a',
+              scripts: {
+                test: 'echo "Error: no test specified" && exit 1',
+              },
+              version: '1.0.0',
+              readme: 'ERROR: No README data found!',
+              dependencies: {},
+              devDependencies: {},
+              optionalDependencies: {},
+              _dependencies: {},
+              path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-a',
+              error: '[Circular]',
+              extraneous: false,
+            },
+          },
+          license: 'ISC',
+          main: 'index.js',
+          name: 'samchungy-a',
+          scripts: {
+            test: 'echo "Error: no test specified" && exit 1',
+          },
+          version: '2.0.0',
+          readme: 'ERROR: No README data found!',
+          devDependencies: {},
+          optionalDependencies: {},
+          _dependencies: {
+            'samchungy-dep-a': '1.0.0',
+          },
+          path: '/workdir/.esbuild/.build/node_modules/samchungy-a',
+          error: '[Circular]',
+          extraneous: false,
+        },
+        'samchungy-b': {
+          _args: [
+            ['samchungy-b@2.0.0', '/workdir/.esbuild/.build'],
+            ['samchungy-b@2.0.0', '/workdir/.esbuild/.build'],
+          ],
+          _from: 'samchungy-b@2.0.0',
+          _id: 'samchungy-b@2.0.0',
+          _integrity:
+            'sha512-i42OG9FC2Py3RfbI8bBFZi3VoN7+MxM0OUvFcWrsIgqvZMUDVI4hNKHqpE6GTt07gDDqQnxlMNehbrsQLtHRVA==',
+          _location: '/samchungy-b',
+          _phantomChildren: {},
+          _requested: {
+            type: 'version',
+            registry: true,
+            raw: 'samchungy-b@2.0.0',
+            name: 'samchungy-b',
+            escapedName: 'samchungy-b',
+            rawSpec: '2.0.0',
+            saveSpec: '[Circular]',
+            fetchSpec: '2.0.0',
+          },
+          _requiredBy: ['/'],
+          _resolved: 'https://registry.npmjs.org/samchungy-b/-/samchungy-b-2.0.0.tgz',
+          _spec: '2.0.0',
+          _where: '/workdir/.esbuild/.build',
+          author: '',
+          dependencies: {
+            'samchungy-dep-a': {
+              _args: [
+                ['samchungy-dep-a@2.0.0', '/workdir/.esbuild/.build'],
+                ['samchungy-dep-a@2.0.0', '/workdir/.esbuild/.build'],
+              ],
+              _from: 'samchungy-dep-a@2.0.0',
+              _id: 'samchungy-dep-a@2.0.0',
+              _integrity:
+                'sha512-Yp30ASjwmyLWCGhlLTqWZa8MlBeBiaaHsmxXMwwQxK/o044vhCsPeugHqhtsZq7Xiq68/TcBux/LKId6eyPNjA==',
+              _location: '/samchungy-b/samchungy-dep-a',
+              _phantomChildren: {},
+              _requested: {
+                type: 'version',
+                registry: true,
+                raw: 'samchungy-dep-a@2.0.0',
+                name: 'samchungy-dep-a',
+                escapedName: 'samchungy-dep-a',
+                rawSpec: '2.0.0',
+                saveSpec: '[Circular]',
+                fetchSpec: '2.0.0',
+              },
+              _requiredBy: ['/samchungy-b'],
+              _resolved: 'https://registry.npmjs.org/samchungy-dep-a/-/samchungy-dep-a-2.0.0.tgz',
+              _spec: '2.0.0',
+              _where: '/workdir/.esbuild/.build',
+              author: '',
+              license: 'ISC',
+              main: 'index.js',
+              name: 'samchungy-dep-a',
+              scripts: {
+                test: 'echo "Error: no test specified" && exit 1',
+              },
+              version: '2.0.0',
+              readme: 'ERROR: No README data found!',
+              dependencies: {},
+              devDependencies: {},
+              optionalDependencies: {},
+              _dependencies: {},
+              path: '/workdir/.esbuild/.build/node_modules/samchungy-b/node_modules/samchungy-dep-a',
+              error: '[Circular]',
+              extraneous: false,
+            },
+          },
+          license: 'ISC',
+          main: 'index.js',
+          name: 'samchungy-b',
+          scripts: {
+            test: 'echo "Error: no test specified" && exit 1',
+          },
+          version: '2.0.0',
+          readme: 'ERROR: No README data found!',
+          devDependencies: {},
+          optionalDependencies: {},
+          _dependencies: {
+            'samchungy-dep-a': '2.0.0',
+          },
+          path: '/workdir/.esbuild/.build/node_modules/samchungy-b',
+          error: '[Circular]',
+          extraneous: false,
+        },
+      },
+      readme: 'ERROR: No README data found!',
+      _id: 'serverless-example@1.0.0',
+      _shrinkwrap: {
+        name: 'serverless-example',
+        version: '1.0.0',
+        lockfileVersion: 1,
+        requires: true,
+        dependencies: {
+          'samchungy-a': {
+            version: '2.0.0',
+            resolved: 'https://registry.npmjs.org/samchungy-a/-/samchungy-a-2.0.0.tgz',
+            integrity:
+              'sha512-gUv/cvd9AFYvvGep0e9m1wSAf3dfnb71eri5TjtgC6N7qvJALXFaFVOkLNBHEYGEm2ZJdosXvGqr3ISZ7Yh46Q==',
+            requires: {
+              'samchungy-dep-a': '1.0.0',
+            },
+          },
+          'samchungy-b': {
+            version: '2.0.0',
+            resolved: 'https://registry.npmjs.org/samchungy-b/-/samchungy-b-2.0.0.tgz',
+            integrity:
+              'sha512-i42OG9FC2Py3RfbI8bBFZi3VoN7+MxM0OUvFcWrsIgqvZMUDVI4hNKHqpE6GTt07gDDqQnxlMNehbrsQLtHRVA==',
+            requires: {
+              'samchungy-dep-a': '2.0.0',
+            },
+            dependencies: {
+              'samchungy-dep-a': {
+                version: '2.0.0',
+                resolved: 'https://registry.npmjs.org/samchungy-dep-a/-/samchungy-dep-a-2.0.0.tgz',
+                integrity:
+                  'sha512-Yp30ASjwmyLWCGhlLTqWZa8MlBeBiaaHsmxXMwwQxK/o044vhCsPeugHqhtsZq7Xiq68/TcBux/LKId6eyPNjA==',
+              },
+            },
+          },
+          'samchungy-dep-a': {
+            version: '1.0.0',
+            resolved: 'https://registry.npmjs.org/samchungy-dep-a/-/samchungy-dep-a-1.0.0.tgz',
+            integrity:
+              'sha512-NVac5aAU+p7bsIrUTQO438vAO8MHyNILbeckhzxhadIUqGx3L9kEZ5HTqZ+XqDIRARmOU6UmFtus6Bc7q5+mWA==',
+          },
+        },
+      },
+      devDependencies: {},
+      optionalDependencies: {},
+      _dependencies: {
+        'samchungy-a': '2.0.0',
+        'samchungy-b': '2.0.0',
+      },
+      path: '/workdir/.esbuild/.build',
+      error: '[Circular]',
+      extraneous: false,
+    };
+    spawnSpy
+      .mockResolvedValueOnce({ stderr: '', stdout: '6.0.0' })
+      .mockResolvedValueOnce({ stderr: '', stdout: JSON.stringify(depsList) });
+
+    const dependencies = await npm.getProdDependencies(path);
+    expect(dependencies).toStrictEqual({
+      dependencies: {
+        'samchungy-a': {
+          dependencies: {
+            'samchungy-dep-a': {
+              isRootDep: true,
+              version: '1.0.0',
+            },
+          },
+          version: '2.0.0',
+        },
+        'samchungy-b': {
+          dependencies: {
+            'samchungy-dep-a': {
+              version: '2.0.0',
+            },
+          },
+          version: '2.0.0',
+        },
+        'samchungy-dep-a': {
+          version: '1.0.0',
+        },
+      },
+    });
+  });
+
+  it('should create a dependency tree from npm v7 output', async () => {
+    const depsList: NpmDeps = {
+      version: '1.0.0',
+      name: 'serverless-example',
+      description: 'Packaged externals for serverless-example',
+      private: true,
+      scripts: {},
+      _id: 'serverless-example@1.0.0',
+      extraneous: false,
+      path: '/workdir/.esbuild/.build',
+      _dependencies: {
+        'samchungy-a': '2.0.0',
+        'samchungy-b': '2.0.0',
+      },
+      devDependencies: {},
+      peerDependencies: {},
+      dependencies: {
+        'samchungy-a': {
+          version: '2.0.0',
+          resolved: 'https://registry.npmjs.org/samchungy-a/-/samchungy-a-2.0.0.tgz',
+          name: 'samchungy-a',
+          integrity:
+            'sha512-gUv/cvd9AFYvvGep0e9m1wSAf3dfnb71eri5TjtgC6N7qvJALXFaFVOkLNBHEYGEm2ZJdosXvGqr3ISZ7Yh46Q==',
+          _id: 'samchungy-a@2.0.0',
+          extraneous: false,
+          path: '/workdir/.esbuild/.build/node_modules/samchungy-a',
+          _dependencies: {
+            'samchungy-dep-a': '1.0.0',
+          },
+          devDependencies: {},
+          peerDependencies: {},
+          dependencies: {
+            'samchungy-dep-a': {
+              version: '1.0.0',
+              resolved: 'https://registry.npmjs.org/samchungy-dep-a/-/samchungy-dep-a-1.0.0.tgz',
+              name: 'samchungy-dep-a',
+              integrity:
+                'sha512-NVac5aAU+p7bsIrUTQO438vAO8MHyNILbeckhzxhadIUqGx3L9kEZ5HTqZ+XqDIRARmOU6UmFtus6Bc7q5+mWA==',
+              _id: 'samchungy-dep-a@1.0.0',
+              extraneous: false,
+              path: '/workdir/.esbuild/.build/node_modules/samchungy-dep-a',
+              _dependencies: {},
+              devDependencies: {},
+              peerDependencies: {},
+            },
+          },
+        },
+        'samchungy-b': {
+          version: '2.0.0',
+          resolved: 'https://registry.npmjs.org/samchungy-b/-/samchungy-b-2.0.0.tgz',
+          name: 'samchungy-b',
+          integrity:
+            'sha512-i42OG9FC2Py3RfbI8bBFZi3VoN7+MxM0OUvFcWrsIgqvZMUDVI4hNKHqpE6GTt07gDDqQnxlMNehbrsQLtHRVA==',
+          _id: 'samchungy-b@2.0.0',
+          extraneous: false,
+          path: '/workdir/.esbuild/.build/node_modules/samchungy-b',
+          _dependencies: {
+            'samchungy-dep-a': '2.0.0',
+          },
+          devDependencies: {},
+          peerDependencies: {},
+          dependencies: {
+            'samchungy-dep-a': {
+              version: '2.0.0',
+              resolved: 'https://registry.npmjs.org/samchungy-dep-a/-/samchungy-dep-a-2.0.0.tgz',
+              name: 'samchungy-dep-a',
+              integrity:
+                'sha512-Yp30ASjwmyLWCGhlLTqWZa8MlBeBiaaHsmxXMwwQxK/o044vhCsPeugHqhtsZq7Xiq68/TcBux/LKId6eyPNjA==',
+              _id: 'samchungy-dep-a@2.0.0',
+              extraneous: false,
+              path: '/workdir/.esbuild/.build/node_modules/samchungy-b/node_modules/samchungy-dep-a',
+              _dependencies: {},
+              devDependencies: {},
+              peerDependencies: {},
+            },
+          },
+        },
+      },
+    };
+    spawnSpy
+      .mockResolvedValueOnce({ stderr: '', stdout: '7.0.0' })
+      .mockResolvedValueOnce({ stderr: '', stdout: JSON.stringify(depsList) });
+
+    const dependencies = await npm.getProdDependencies(path);
+    expect(dependencies).toStrictEqual({
+      dependencies: {
+        'samchungy-a': {
+          dependencies: {
+            'samchungy-dep-a': {
+              isRootDep: true,
+              version: '1.0.0',
+            },
+          },
+          version: '2.0.0',
+        },
+        'samchungy-b': {
+          dependencies: {
+            'samchungy-dep-a': {
+              version: '2.0.0',
+            },
+          },
+          version: '2.0.0',
+        },
+        'samchungy-dep-a': {
+          version: '1.0.0',
+        },
+      },
+    });
   });
 });

--- a/src/tests/packagers/yarn.test.ts
+++ b/src/tests/packagers/yarn.test.ts
@@ -1,0 +1,233 @@
+import { Yarn, YarnDeps } from '../../packagers/yarn';
+import { DependenciesResult } from '../../types';
+
+import * as utils from '../../utils';
+
+jest.mock('process');
+describe('Yarn Packager', () => {
+  const yarn = new Yarn();
+  const path = './';
+
+  let spawnSpy = jest.spyOn(utils, 'spawnProcess');
+
+  beforeEach(() => {
+    spawnSpy = jest.spyOn(utils, 'spawnProcess');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('should call spawnProcess with the correct arguments for listing yarn dependencies', async () => {
+    spawnSpy.mockResolvedValueOnce({
+      stderr: '',
+      stdout: '{"type":"tree","data":{"type":"list","trees":[]}}',
+    });
+
+    await yarn.getProdDependencies(path);
+
+    expect(spawnSpy).toBeCalledTimes(1);
+    expect(spawnSpy).toBeCalledWith('yarn', ['list', '--json', '--production'], { cwd: './' });
+  });
+
+  it('should call spawnProcess with the correct arguments for listing yarn dependencies when depth is provided', async () => {
+    spawnSpy.mockResolvedValueOnce({
+      stderr: '',
+      stdout: '{"type":"tree","data":{"type":"list","trees":[]}}',
+    });
+
+    await yarn.getProdDependencies(path, 2);
+
+    expect(spawnSpy).toBeCalledTimes(1);
+    expect(spawnSpy).toBeCalledWith('yarn', ['list', '--depth=2', '--json', '--production'], {
+      cwd: './',
+    });
+  });
+
+  it('should create a dependency tree from yarn output', async () => {
+    const yarnOutput: YarnDeps = {
+      type: 'tree',
+      data: {
+        type: 'list',
+        trees: [
+          {
+            name: 'samchungy-a@2.0.0',
+            children: [
+              {
+                name: 'samchungy-dep-a@1.0.0',
+                color: 'dim',
+                shadow: true,
+              },
+            ],
+            hint: null,
+            color: 'bold',
+            depth: 0,
+          },
+          {
+            name: 'samchungy-b@2.0.0',
+            children: [
+              {
+                name: 'samchungy-dep-a@2.0.0',
+                color: 'dim',
+                shadow: true,
+              },
+              {
+                name: 'samchungy-dep-a@2.0.0',
+                children: [],
+                hint: null,
+                color: 'bold',
+                depth: 0,
+              },
+            ],
+            hint: null,
+            color: 'bold',
+            depth: 0,
+          },
+          {
+            name: 'samchungy-dep-a@1.0.0',
+            children: [],
+            hint: null,
+            color: null,
+            depth: 0,
+          },
+        ],
+      },
+    };
+    const expectedResult: DependenciesResult = {
+      dependencies: {
+        'samchungy-a': {
+          dependencies: {
+            'samchungy-dep-a': {
+              isRootDep: true,
+              version: '1.0.0',
+            },
+          },
+          version: '2.0.0',
+        },
+        'samchungy-b': {
+          dependencies: {
+            'samchungy-dep-a': {
+              version: '2.0.0',
+            },
+          },
+          version: '2.0.0',
+        },
+        'samchungy-dep-a': {
+          version: '1.0.0',
+        },
+      },
+    };
+
+    spawnSpy.mockResolvedValueOnce({
+      stderr: '',
+      stdout: JSON.stringify(yarnOutput),
+    });
+
+    const result = await yarn.getProdDependencies(path, 2);
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+
+  it('should create a dependency tree which handles deduping from yarn output', async () => {
+    const yarnOutput: YarnDeps = {
+      type: 'tree',
+      data: {
+        type: 'list',
+        trees: [
+          {
+            name: 'samchungy-a@3.0.0',
+            children: [{ name: 'samchungy-dep-b@3.0.0', color: 'dim', shadow: true }],
+            hint: null,
+            color: 'bold',
+            depth: 0,
+          },
+          {
+            name: 'samchungy-b@5.0.0',
+            children: [{ name: 'samchungy-dep-b@3.0.0', color: 'dim', shadow: true }],
+            hint: null,
+            color: 'bold',
+            depth: 0,
+          },
+          {
+            name: 'samchungy-dep-b@3.0.0',
+            children: [
+              { name: 'samchungy-dep-c@^1.0.0', color: 'dim', shadow: true },
+              { name: 'samchungy-dep-d@^1.0.0', color: 'dim', shadow: true },
+            ],
+            hint: null,
+            color: null,
+            depth: 0,
+          },
+          {
+            name: 'samchungy-dep-c@1.0.0',
+            children: [{ name: 'samchungy-dep-e@^1.0.0', color: 'dim', shadow: true }],
+            hint: null,
+            color: null,
+            depth: 0,
+          },
+          {
+            name: 'samchungy-dep-d@1.0.0',
+            children: [{ name: 'samchungy-dep-e@^1.0.0', color: 'dim', shadow: true }],
+            hint: null,
+            color: null,
+            depth: 0,
+          },
+          {
+            name: 'samchungy-dep-e@1.0.0',
+            children: [],
+            hint: null,
+            color: null,
+            depth: 0,
+          },
+        ],
+      },
+    };
+
+    const expectedResult: DependenciesResult = {
+      dependencies: {
+        'samchungy-a': {
+          version: '3.0.0',
+          dependencies: {
+            'samchungy-dep-b': { version: '3.0.0', isRootDep: true },
+          },
+        },
+        'samchungy-b': {
+          version: '5.0.0',
+          dependencies: {
+            'samchungy-dep-b': { version: '3.0.0', isRootDep: true },
+          },
+        },
+        'samchungy-dep-b': {
+          version: '3.0.0',
+          dependencies: {
+            'samchungy-dep-c': { version: '^1.0.0', isRootDep: true },
+            'samchungy-dep-d': { version: '^1.0.0', isRootDep: true },
+          },
+        },
+        'samchungy-dep-c': {
+          version: '1.0.0',
+          dependencies: {
+            'samchungy-dep-e': { version: '^1.0.0', isRootDep: true },
+          },
+        },
+        'samchungy-dep-d': {
+          version: '1.0.0',
+          dependencies: {
+            'samchungy-dep-e': { version: '^1.0.0', isRootDep: true },
+          },
+        },
+        'samchungy-dep-e': { version: '1.0.0' },
+      },
+    };
+
+    spawnSpy.mockResolvedValueOnce({
+      stderr: '',
+      stdout: JSON.stringify(yarnOutput),
+    });
+
+    const result = await yarn.getProdDependencies(path, 2);
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,17 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type JSONObject = any;
 
+export type Dependencies = Record<string, Dependency>;
+
+export interface Dependency {
+  version: string;
+  dependencies?: Dependencies;
+  /** This means that the dependency is available from the root node_modules folder */
+  resolved?: boolean;
+}
+
 export interface IFile {
-  readonly localPath: string
-  readonly rootPath: string
+  readonly localPath: string;
+  readonly rootPath: string;
 }
 export type IFiles = readonly IFile[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,8 @@ export type DependencyMap = Record<string, DependencyTree>;
 export interface DependencyTree {
   version: string;
   dependencies?: DependencyMap;
-  /** This means that the dependency is available from the root node_modules folder */
-  resolved?: boolean;
+  /** Indicates the dependency is available from the root node_modules folder/root of this tree */
+  isRootDep?: boolean;
 }
 
 export interface IFile {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type JSONObject = any;
 
-export type Dependencies = Record<string, Dependency>;
+export interface DependenciesResult {
+  stdout?: string;
+  dependencies?: DependencyMap;
+}
 
-export interface Dependency {
+export type DependencyMap = Record<string, DependencyTree>;
+
+export interface DependencyTree {
   version: string;
-  dependencies?: Dependencies;
+  dependencies?: DependencyMap;
   /** This means that the dependency is available from the root node_modules folder */
   resolved?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,3 +169,8 @@ export const zip = async (
 export function trimExtension(entry: string) {
   return entry.slice(0, -path.extname(entry).length);
 }
+
+export const isEmpty = (obj: Record<string, unknown>) => {
+  for (const _i in obj) return false;
+  return true;
+};


### PR DESCRIPTION
## Why
Resolves #265
Resolves #103
Resolves #135

- The current `yarn` dependency resolution logic does not take into consideration the version of the package it is looking for. This meant that if there was another version of a package of the same name with different dependencies we may not bring the correct dependencies into the package. This could cause extra or less packages to be included in the package.

- The current `npm` dependency resolution logic does not consider when a package is de-duped by another package. This leads to issues when multiple dependencies share the same version dependency.

## Change
- Unify output of the dependency tree shape and behavior of `npm` and `yarn` packagers. This should hopefully lead to more consistency.
- Update `flatdep` logic

## WIP Checklist
- [x] Come up with shape for unified dependency tree
- [x] Shape `yarn` dependency output to unified tree
- [x] Shape `npm` dependency output to unified tree
- [x] Shape `pnpm` dependency output to unified tree [Won't fix - see #269 ]
- [x] Change `flatDep` logic
- [x] Unit Test Coverage