### PR TITLE
fix(external): correct detection of packages with subpath require

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -86,13 +86,23 @@ export const flatDep = (deps: JSONObject, filter?: string[], originalObject?: JS
 };
 
 /**
+ * Extracts the base package from a package string taking scope into consideration
+ * @example getBasePackage('@scope/package/register') returns '@scope/package'
+ * @example getBasePackage('package/register') returns 'package'
+ * @example getBasePackage('package') returns 'package'
+ * @param path
+ */
+const getBasePackage = (path: string): string => /^@[^/]+\/[^/\n]+|^[^/\n]+/.exec(path)[0];
+
+/**
  * Extracts the list of dependencies that appear in a bundle as `require(XXX)`
  * @param bundlePath Absolute path to a bundled JS file
  */
-export const getDepsFromBundle = (bundlePath: string) => {
+export const getDepsFromBundle = (bundlePath: string): string[] => {
   const bundleContent = fs.readFileSync(bundlePath, 'utf8');
   const requireMatch = matchAll(bundleContent, /require\("(.*?)"\)/gim);
-  return uniq(Array.from(requireMatch).map((match) => match[1]));
+  const deps = Array.from<string>(requireMatch).map((match) => match[1]);
+  return uniq(deps.map((dep): string => getBasePackage(dep)));
 };
 
 export const doSharePath = (child, parent) => {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -87,12 +87,12 @@ export const flatDep = (deps: JSONObject, filter?: string[], originalObject?: JS
 
 /**
  * Extracts the base package from a package string taking scope into consideration
- * @example getBasePackage('@scope/package/register') returns '@scope/package'
- * @example getBasePackage('package/register') returns 'package'
- * @example getBasePackage('package') returns 'package'
+ * @example getBaseDep('@scope/package/register') returns '@scope/package'
+ * @example getBaseDep('package/register') returns 'package'
+ * @example getBaseDep('package') returns 'package'
  * @param path
  */
-const getBasePackage = (path: string): string => /^@[^/]+\/[^/\n]+|^[^/\n]+/.exec(path)[0];
+const getBaseDep = (path: string): string => /^@[^/]+\/[^/\n]+|^[^/\n]+/.exec(path)[0];
 
 /**
  * Extracts the list of dependencies that appear in a bundle as `require(XXX)`
@@ -102,7 +102,7 @@ export const getDepsFromBundle = (bundlePath: string): string[] => {
   const bundleContent = fs.readFileSync(bundlePath, 'utf8');
   const requireMatch = matchAll(bundleContent, /require\("(.*?)"\)/gim);
   const deps = Array.from<string>(requireMatch).map((match) => match[1]);
-  return uniq(deps.map((dep): string => getBasePackage(dep)));
+  return uniq(deps.map((dep): string => getBaseDep(dep)));
 };
 
 export const doSharePath = (child, parent) => {

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -147,12 +147,12 @@ describe('extractFileNames', () => {
 
 describe('getDepsFromBundle', () => {
   const path = './';
-  it('should extract packages from a string', () => {
+  it('should extract deps from a string', () => {
     mocked(fs).readFileSync.mockReturnValue('require("@scope/package1");require("package2")');
     expect(getDepsFromBundle(path)).toStrictEqual(['@scope/package1', 'package2']);
   });
 
-  it('should extract the base package of requires from a string', () => {
+  it('should extract the base dep from a string', () => {
     mocked(fs).readFileSync.mockReturnValue(
       'require("@scope/package1/subpath");require("package2/subpath");require("@scope/package3/subpath/subpath")require("package4/subpath/subpath")'
     );


### PR DESCRIPTION
Resolves #268

Packages being imported with subpaths were not being picked up.

This takes into consideration scoped packages

```
@scope/package -> @scope/package
@scope/package/subpath -> @scope/package
@scope/package/subpath/subpath -> @scope/package
package -> package
package/subpath -> package
```

### Before
<img width="346" alt="image" src="https://user-images.githubusercontent.com/18017094/153572660-e8601ec4-c914-48d2-a680-6472664354ac.png">

### After
<img width="377" alt="image" src="https://user-images.githubusercontent.com/18017094/153572844-60c84b4f-9131-4147-ab75-20b4407050a5.png">

