### PR TITLE
ci: bump up node version for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - run: npm install
       - run: npx semantic-release
         env:


### PR DESCRIPTION
Ruh roh, this version of semantic release requires node 14 to run 😆 . Feel free to merge whenever.