### PR TITLE
Fix: Always copy pattern matched files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -321,9 +321,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
           fs.mkdirpSync(dirname);
         }
 
-        if (!fs.existsSync(destFileName)) {
-          fs.copySync(path.resolve(filename), destFileName);
-        }
+        await fs.copy(path.resolve(filename), destFileName);
       }
     }
 
@@ -343,9 +341,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
           fs.mkdirpSync(dirname);
         }
 
-        if (!fs.existsSync(destFileName)) {
-          fs.copySync(path.resolve(filename), destFileName);
-        }
+        await fs.copy(path.resolve(filename), destFileName);
       }
     }
   }


### PR DESCRIPTION
This allows offline development to always have the latest extra files in the output folder.

Switch to async file copying.

fixes: #277