### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior. If you have an example repository that would be even better:
+1. Set X to `true`
+2. Run `sls package`
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots or Logs**
+If applicable, add screenshots or logs to help explain your problem.
+
+**Versions (please complete the following information):**
+ - OS: [e.g. Linux, Mac, Windows]
+ - Serverless Framework Version: [e.g. 3.0.0]
+ - Plugin Version: [e.g. 1.25.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
We get alot of reports with not enough information and most of the time we have to ask them for logs, or steps to reproduce. 
These templates were generated automatically by GitHub. I just tweaked them to be more specific to our plugin