### PR TITLE
chore: use serverless v3 option types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14656,9 +14656,9 @@
       "dev": true
     },
     "@types/serverless": {
-      "version": "1.78.39",
-      "resolved": "https://registry.npmjs.org/@types/serverless/-/serverless-1.78.39.tgz",
-      "integrity": "sha512-AcQ58tUIiNgFJw49p51JYOOwWftTJJlwIca5s3ONaSouwr7OC3m6Hpe7cM1K818sAwSttGq94V4B3O8sTdioCw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/serverless/-/serverless-3.0.1.tgz",
+      "integrity": "sha512-HqdKXULKs47ntFILOUdU18LLl0snKC+rpgHSy+zrXLmVU/E1Ef9w+VDwR+Opc//PpdT98SDCcQC6gcu7Gsy/DA==",
       "dev": true
     },
     "@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/node": "^12.12.38",
     "@types/ramda": "0.27.40",
     "@types/semver": "^7.3.8",
-    "@types/serverless": "^3.0.0",
+    "@types/serverless": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "esbuild": "^0.14.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,13 +19,7 @@ import { preOffline } from './pre-offline';
 import { preLocal } from './pre-local';
 import { trimExtension } from './utils';
 import { BUILD_FOLDER, ONLY_PREFIX, SERVERLESS_FOLDER, WORK_FOLDER } from './constants';
-import {
-  Configuration,
-  FunctionBuildResult,
-  OptionsExtended,
-  Plugins,
-  ReturnPluginsFn,
-} from './types';
+import { Configuration, FunctionBuildResult, Plugins, ReturnPluginsFn } from './types';
 
 const DEFAULT_BUILD_OPTIONS: Partial<Configuration> = {
   bundle: true,
@@ -51,7 +45,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
   log: ServerlessPlugin.Logging['log'];
 
   serverless: Serverless;
-  options: OptionsExtended;
+  options: Serverless.Options;
   hooks: ServerlessPlugin.Hooks;
   buildResults: FunctionBuildResult[];
   packExternalModules: () => Promise<void>;
@@ -61,7 +55,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
 
   constructor(
     serverless: Serverless,
-    options: OptionsExtended,
+    options: Serverless.Options,
     logging?: ServerlessPlugin.Logging
   ) {
     this.serverless = serverless;

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,7 +1,6 @@
 import Serverless from 'serverless';
 import Service from 'serverless/classes/Service';
 import EsbuildServerlessPlugin from '../index';
-import { OptionsExtended } from '../types';
 
 import fs from 'fs-extra';
 
@@ -59,7 +58,7 @@ const mockServerlessConfig = (serviceOverride?: Partial<Service>): Serverless =>
   } as Partial<Serverless> as Serverless;
 };
 
-const mockOptions: OptionsExtended = {
+const mockOptions: Serverless.Options = {
   region: 'us-east-1',
   stage: 'dev',
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,6 @@ import Serverless from 'serverless';
 export type Plugins = Plugin[];
 export type ReturnPluginsFn = (sls: Serverless) => Plugins;
 
-export interface OptionsExtended extends Serverless.Options {
-  verbose?: boolean;
-}
-
 export interface WatchConfiguration {
   pattern?: string[] | string;
   ignore?: string[] | string;


### PR DESCRIPTION
Hello ! Following https://github.com/floydspace/serverless-esbuild/pull/282, I added the `verbose` options to `@types/serverless`, so it is no longer necessary to extend its definition.

See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58992

Cheers!