### PR TITLE
fix: handle empty or missing npm dependency tree

### DIFF
--- a/src/packagers/npm.ts
+++ b/src/packagers/npm.ts
@@ -224,7 +224,10 @@ export class NPM implements Packager {
     };
 
     return {
-      dependencies: convertTrees(parsedDeps.dependencies, {}),
+      ...(parsedDeps.dependencies &&
+        !isEmpty(parsedDeps.dependencies) && {
+          dependencies: convertTrees(parsedDeps.dependencies, {}),
+        }),
     };
   }
 

--- a/src/tests/packagers/npm.test.ts
+++ b/src/tests/packagers/npm.test.ts
@@ -1003,4 +1003,33 @@ describe('NPM Packager', () => {
     expect(v6dependencies).toStrictEqual(expectedResult);
     expect(v7dependencies).toStrictEqual(expectedResult);
   });
+
+  it('should handle no dependencies returned from npm output', async () => {
+    const v6depsList: NpmV6Deps = {
+      name: 'serverless-example',
+      version: '1.0.0',
+      description: 'Packaged externals for serverless-example',
+      private: true,
+      scripts: {},
+      readme: 'ERROR: No README data found!',
+      _id: 'serverless-example@1.0.0',
+      _shrinkwrap: {},
+      devDependencies: {},
+      optionalDependencies: {},
+      _dependencies: {},
+      path: '/workdir/.esbuild/.build',
+      error: '[Circular]',
+      extraneous: false,
+    };
+
+    const expectedResult: DependenciesResult = {};
+
+    spawnSpy
+      .mockResolvedValueOnce({ stderr: '', stdout: '6.0.0' })
+      .mockResolvedValueOnce({ stderr: '', stdout: JSON.stringify(v6depsList) });
+
+    const v6dependencies = await npm.getProdDependencies(path);
+
+    expect(v6dependencies).toStrictEqual(expectedResult);
+  });
 });


### PR DESCRIPTION
Resolves #286

I think we should consider enabling `"strictNullChecks": true` which I'm used to having on most of my repos. But I may try this in a different PR as I think there might be a few other code smells around the place.