### PR TITLE
fix: ignore npm v7+ err ELSPROBLEMS

### DIFF
--- a/src/tests/packagers/npm.test.ts
+++ b/src/tests/packagers/npm.test.ts
@@ -1004,14 +1004,6 @@ describe('NPM Packager', () => {
     expect(v7dependencies).toStrictEqual(expectedResult);
   });
 
-  test.each([
-    { a: 1, b: 1, expected: 2 },
-    { a: 1, b: 2, expected: 3 },
-    { a: 2, b: 1, expected: 3 },
-  ])('.add($a, $b)', ({ a, b, expected }) => {
-    expect(a + b).toBe(expected);
-  });
-
   it.each([
     'npm ERR! code ELSPROBLEMS',
     'npm ERR! extraneous: foo@1.2.3 ./bar/node_modules/foo',


### PR DESCRIPTION
fixes https://github.com/floydspace/serverless-esbuild/issues/288
cribbed from https://github.com/serverless-heaven/serverless-webpack/pull/782
simplified ignored error checking (removed ramda reduce in favour of ES5+ native `Array.every()`