### PR TITLE
fix: use fs.createWriteStream instead of fs-extra

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import { bestzip } from 'bestzip';
 import archiver from 'archiver';
 import childProcess from 'child_process';
 import fs from 'fs-extra';
+import nodeFs from 'fs';
 import path from 'path';
 import os from 'os';
 import { join } from 'ramda';
@@ -134,7 +135,7 @@ export const zip = async (
     fs.rmdirSync(tempDirPath, { recursive: true });
   } else {
     const zip = archiver.create('zip');
-    const output = fs.createWriteStream(zipPath);
+    const output = nodeFs.createWriteStream(zipPath);
 
     // write zip
     output.on('open', () => {


### PR DESCRIPTION
In one of our services the packaging process seems to be hanging [after opening the write stream to a zipped file](https://github.com/floydspace/serverless-esbuild/blob/a2516d754663a867416dc3bab200faf0863c3729/src/utils.ts#L140). The stream seems to be creates, but the `open` event never fires. Nothing is written to the file and no errors occur.

I couldn't find any difference between several projects and this one, and the only thing that seems to have helped is switching to using `createWriteStream` from the `fs` package instead of `fs-extra`. I don't think using `fs-extra` for this particular function provides any benefit? 

Weirdly enough, if I create a separate file like this and run it I get the contents written to the file:
```
const fs = require("fs-extra");
const output = fs.createWriteStream(/* zip path here */);

output.on('open', () => {
  output.write('test')
  output.end()
});
```

Please let me know how to procedd. Thanks.
