### PR TITLE
Add variable to skip external packing

### DIFF
--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -204,7 +204,9 @@ function getProdModules(
  */
 export async function packExternalModules(this: EsbuildServerlessPlugin) {
   const plugins = this.plugins;
-
+  if (this.buildOptions.skipExternalsPacking) {
+    return;
+  }
   if (
     plugins &&
     plugins.map((plugin) => plugin.name).includes('node-externals') &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface Configuration extends Omit<BuildOptions, 'nativeZip' | 'watch' 
   keepOutputDirectory?: boolean;
   packagerOptions?: PackagerOptions;
   disableIncremental?: boolean;
+  skipExternalsPacking?: boolean;
 }
 
 export interface FunctionBuildResult {


### PR DESCRIPTION
## Background
I have several serverless functions that share node_modules, I created a layer containing those node_modules so I do not need to package the dependencies inside the bundle.

### Additional information
I'm working on a windows machine and the tests and husky hooks are not properly working (paths in the expected unit test results are hardcoded in unix style). In future a PR that fixes this could be useful.
