### PR TITLE
fix: prevent circular dependency loop in flatDep

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -91,8 +91,8 @@ export const flatDep = (root: DependencyMap, rootDepsFilter: string[]): string[]
         // We already have this root dep and it's dependencies - skip this iteration
         if (flattenedDependencies.has(depName)) return;
 
-        recursiveFind(root[depName].dependencies);
         flattenedDependencies.add(depName);
+        recursiveFind(root[depName].dependencies);
         return;
       }
 

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -223,7 +223,7 @@ describe('flatDeps', () => {
         },
       };
 
-      const expectedResult: string[] = ['samchungy-dep-a', 'samchungy-a', 'samchungy-b'];
+      const expectedResult: string[] = ['samchungy-a', 'samchungy-dep-a', 'samchungy-b'];
 
       const result = flatDep(depMap, ['samchungy-a', 'samchungy-b']);
 
@@ -300,11 +300,11 @@ describe('flatDeps', () => {
       };
 
       const expectedResult: string[] = [
-        'samchungy-dep-e',
-        'samchungy-dep-c',
-        'samchungy-dep-d',
-        'samchungy-dep-b',
         'samchungy-a',
+        'samchungy-dep-b',
+        'samchungy-dep-c',
+        'samchungy-dep-e',
+        'samchungy-dep-d',
         'samchungy-b',
       ];
 
@@ -350,11 +350,11 @@ describe('flatDeps', () => {
       };
 
       const expectedResult: string[] = [
-        'samchungy-dep-e',
-        'samchungy-dep-c',
-        'samchungy-dep-d',
-        'samchungy-dep-b',
         'samchungy-a',
+        'samchungy-dep-b',
+        'samchungy-dep-c',
+        'samchungy-dep-e',
+        'samchungy-dep-d',
         'samchungy-b',
       ];
 


### PR DESCRIPTION
Tweak the `flatDep` logic to add the dependency to the found list before finding other dependencies. This should prevent any circular dependency issues arising in the future.

https://github.com/floydspace/serverless-esbuild/issues/205#issuecomment-1089264328