### PR TITLE
feat: add nodejs16.x runtime support

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ AWS:
 
 | Runtime      | Target   |
 | ------------ | -------- |
+| `nodejs16.x` | `node16` |
 | `nodejs14.x` | `node14` |
 | `nodejs12.x` | `node12` |
 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -142,6 +142,7 @@ export const doSharePath = (child, parent) => {
 
 export const providerRuntimeMatcher = Object.freeze({
   aws: {
+    'nodejs16.x': 'node16',
     'nodejs14.x': 'node14',
     'nodejs12.x': 'node12',
   },


### PR DESCRIPTION
Hi! nodejs16.x lambda runtime was just released, this adds support for using it together with serverless-esbuild