### PR TITLE
fix: use relative path for artifact file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -397,17 +397,12 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
 
     if (service.package.individually || this.options.function) {
       Object.values(this.functions).forEach((func) => {
-        func.package.artifact = path.join(
-          this.serviceDirPath,
-          SERVERLESS_FOLDER,
-          path.basename(func.package.artifact)
-        );
+        func.package.artifact = path.join(SERVERLESS_FOLDER, path.basename(func.package.artifact));
       });
       return;
     }
 
     service.package.artifact = path.join(
-      this.serviceDirPath,
       SERVERLESS_FOLDER,
       path.basename(service.package.artifact)
     );

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -92,7 +92,7 @@ describe('Move Artifacts', () => {
             "events": Array [],
             "handler": "hello1.handler",
             "package": Object {
-              "artifact": "/workDir/.serverless/hello1",
+              "artifact": ".serverless/hello1",
             },
           },
         }
@@ -112,14 +112,14 @@ describe('Move Artifacts', () => {
             "events": Array [],
             "handler": "hello1.handler",
             "package": Object {
-              "artifact": "/workDir/.serverless/hello1",
+              "artifact": ".serverless/hello1",
             },
           },
           "hello2": Object {
             "events": Array [],
             "handler": "hello2.handler",
             "package": Object {
-              "artifact": "/workDir/.serverless/hello2",
+              "artifact": ".serverless/hello2",
             },
           },
         }
@@ -145,14 +145,14 @@ describe('Move Artifacts', () => {
             "events": Array [],
             "handler": "hello1.handler",
             "package": Object {
-              "artifact": "/workDir/.serverless/hello1",
+              "artifact": ".serverless/hello1",
             },
           },
           "hello2": Object {
             "events": Array [],
             "handler": "hello2.handler",
             "package": Object {
-              "artifact": "/workDir/.serverless/hello2",
+              "artifact": ".serverless/hello2",
             },
           },
         }
@@ -166,7 +166,7 @@ describe('Move Artifacts', () => {
 
       await plugin.moveArtifacts();
 
-      expect(plugin.serverless.service.package.artifact).toBe('/workDir/.serverless/hello');
+      expect(plugin.serverless.service.package.artifact).toBe('.serverless/hello');
     });
   });
 });


### PR DESCRIPTION
Absolute artifact paths break deployment in scenario where serverless package runs in one folder
and later serverless deploy runs in a different folder (happens in CI/CD systems).
Serverless Framework uses the artifact path to determine the location of the file to copy from.

Closes #324