### PR TITLE
fix: allow to include package.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       'before:package:createDeploymentArtifacts': async () => {
         await this.bundle();
         await this.packExternalModules();
-        await this.copyExtras();
+        await this.copyExtras(true);
         await this.pack();
       },
       'after:package:createDeploymentArtifacts': async () => {
@@ -120,7 +120,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       'before:deploy:function:packageFunction': async () => {
         await this.bundle();
         await this.packExternalModules();
-        await this.copyExtras();
+        await this.copyExtras(true);
         await this.pack();
       },
       'after:deploy:function:packageFunction': async () => {
@@ -347,7 +347,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       return;
     }
 
-    for (const [functionAlias, fn] of Object.entries(this.functions)) {
+    for (const [_, fn] of Object.entries(this.functions)) {
       if (fn.package.patterns.length === 0) {
         continue;
       }
@@ -358,9 +358,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
           filename
         )
       ) {
-        const destFileName = path.resolve(
-          path.join(this.buildDirPath, `${ONLY_PREFIX}${functionAlias}`, filename)
-        );
+        const destFileName = path.resolve(path.join(this.buildDirPath, filename));
         updateFile(op, path.resolve(filename), destFileName);
         return;
       }
@@ -368,7 +366,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
   }
 
   /** Link or copy extras such as node_modules or package.patterns definitions */
-  async copyExtras() {
+  async copyExtras(pack = false) {
     const { service } = this.serverless;
 
     // include any "extras" from the "patterns" section
@@ -389,7 +387,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       const files = await globby(fn.package.patterns);
       for (const filename of files) {
         const destFileName = path.resolve(
-          path.join(this.buildDirPath, `${ONLY_PREFIX}${functionAlias}`, filename)
+          path.join(this.buildDirPath, pack ? `${ONLY_PREFIX}${functionAlias}` : '', filename)
         );
         updateFile('add', path.resolve(filename), destFileName);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,20 +91,16 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     this.hooks = {
       'before:run:run': async () => {
         await this.bundle();
-        await this.packExternalModules();
         await this.copyExtras();
       },
       'before:offline:start': async () => {
         await this.bundle(true);
-        await this.packExternalModules();
         await this.copyExtras();
         await this.preOffline();
         this.watch();
       },
       'before:offline:start:init': async () => {
         await this.bundle(true);
-        await this.packExternalModules();
-        await this.copyExtras();
         await this.preOffline();
         this.watch();
       },
@@ -128,7 +124,6 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       },
       'before:invoke:local:invoke': async () => {
         await this.bundle();
-        await this.packExternalModules();
         await this.copyExtras();
         await this.preLocal();
       },
@@ -347,7 +342,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       return;
     }
 
-    for (const [_, fn] of Object.entries(this.functions)) {
+    for (const [, fn] of Object.entries(this.functions)) {
       if (fn.package.patterns.length === 0) {
         continue;
       }

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -60,6 +60,9 @@ export const filterFilesForZipPackage = ({
       return true;
     }
 
+    // GOOGLE Provider requires a package.json and NO node_modules
+    if (!isGoogleProvider && excludedFilesDefault.includes(localPath)) return false;
+
     // exclude non individual files based on file path (and things that look derived, e.g. foo.js => foo.js.map)
     if (excludedFiles.find((p) => localPath.startsWith(`${p}.`))) return false;
 
@@ -86,9 +89,7 @@ export const filterFilesForZipPackage = ({
 };
 
 export async function pack(this: EsbuildServerlessPlugin) {
-  // GOOGLE Provider requires a package.json and NO node_modules
   const isGoogleProvider = this.serverless?.service?.provider?.name === 'google';
-  const excludedFiles = isGoogleProvider ? [] : excludedFilesDefault;
 
   // Google provider cannot use individual packaging for now - this could be built in a future release
   if (isGoogleProvider && this.serverless?.service?.package?.individually)
@@ -103,7 +104,6 @@ export async function pack(this: EsbuildServerlessPlugin) {
       dot: true,
       onlyFiles: true,
     })
-    .filter((p) => !excludedFiles.includes(p))
     .map((localPath) => ({ localPath, rootPath: path.join(this.buildDirPath, localPath) }));
 
   if (isEmpty(files)) {


### PR DESCRIPTION
Hey guys, I started this PR as a fix for https://github.com/floydspace/serverless-esbuild/issues/315 but then I found other things that I think it could help to optimize the development experience, sorry for the mess.

### allow to include package.json into the `package.patterns
It works in this way:

1. If `individually=false` it should create a zip with everything including package.json and their locks.
2. If `individually=true` the package.json will not being included by default. The developer should include the file to the `package.pattern`.

### In offline mode: avoid to create `__only` paths:
I added a fix about how the plugin is including the extra files based on the `function.package.patterns`.

I understand that the plugin creates specific paths `__only{function}` for every `function.package.patterns`. That's ok for the packaging but if I run a function or I work in offline mode the directories keeps generating to `__only{function}` where the source code cannot get into. So my fix is to work with `__only` directories for packaging and use the real paths for offline development.

### In offline mode: avoid to pack external modules:

I was comparing how long it takes to start the offline mode in esbuild against serverless-webpack and didn't understand why it taking like 5 seconds more in serverless-esbuild. So I found that webpack don't try to pack external modules during the development process. Because there is no `node_module` in the source code will follow the nodejs lookup spec and goes up to find what it needs, by doing this we:
1. Optimize the initial speed up in offline mode from seconds to milliseconds.
2. Reduce the size of the project by no having to duplicate node_modules.
3. Works better with monorepo projects.
