### PR TITLE
fix: packagePath correctly treated as relative path from service dir

### DIFF
--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -75,7 +75,7 @@ function getProdModules(
   packageJsonPath: string,
   rootPackageJsonPath: string
 ) {
-  const packageJson = require(packageJsonPath);
+  const packageJson = this.serverless.utils.readFileSync(packageJsonPath);
   const prodModules = [];
 
   // only process the module stated in dependencies section
@@ -132,6 +132,7 @@ function getProdModules(
       'package.json'
     );
     const localModulePackagePath = path.join(
+      process.cwd(),
       path.dirname(packageJsonPath),
       'node_modules',
       externalModule.external,
@@ -308,7 +309,11 @@ export async function packExternalModules(this: EsbuildServerlessPlugin) {
   );
 
   // (1.a.2) Copy package-lock.json if it exists, to prevent unwanted upgrades
-  const packageLockPath = path.join(path.dirname(packageJsonPath), packager.lockfileName);
+  const packageLockPath = path.join(
+    process.cwd(),
+    path.dirname(packageJsonPath),
+    packager.lockfileName
+  );
   const exists = await fse.pathExists(packageLockPath);
   if (exists) {
     this.log.verbose('Package lock found - Using locked versions');


### PR DESCRIPTION
Hey.

This PR ensures that a provided `packagePath` is always resolved relative to the current working directory e.g serverless.yml dir.

Currently the `packagePath` is resolved based on the directory containing the currently executing file, i.e `/my-project/node_modules/serverless-esbuild/dist/pack-externals.js`;

https://github.com/floydspace/serverless-esbuild/blob/2c1d2ac842ac4270c48028d123887193ae957af2/src/pack-externals.ts#L78


If you change the `packagePath` with this in mind then it fails over when trying to resolve the `package-lock.json` later due to trying to resolve relative to the current working directory.

https://github.com/floydspace/serverless-esbuild/blob/2c1d2ac842ac4270c48028d123887193ae957af2/src/pack-externals.ts#L311

## Considerations:
- I have used `process.cwd()` to determine current working directory as seen in the util function `findUp`.
- This my have gone unnoticed as the log message for whether or not the lock file is used is LEVEL verbose.