### PR TITLE
fix: set buildOptions in new initialize function

### DIFF
--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -70,6 +70,7 @@ afterEach(() => {
 describe('Move Artifacts', () => {
   it('should copy files from the esbuild folder to the serverless folder', async () => {
     const plugin = new EsbuildServerlessPlugin(mockServerlessConfig(), mockOptions);
+    plugin.hooks.initialize();
 
     await plugin.moveArtifacts();
 
@@ -83,6 +84,7 @@ describe('Move Artifacts', () => {
         ...mockOptions,
         function: 'hello1',
       });
+      plugin.hooks.initialize();
 
       await plugin.moveArtifacts();
 
@@ -103,6 +105,7 @@ describe('Move Artifacts', () => {
   describe('package individually', () => {
     it('should update function package artifacts base path to the serverless folder', async () => {
       const plugin = new EsbuildServerlessPlugin(mockServerlessConfig(), mockOptions);
+      plugin.hooks.initialize();
 
       await plugin.moveArtifacts();
 
@@ -136,6 +139,7 @@ describe('Move Artifacts', () => {
         }),
         mockOptions
       );
+      plugin.hooks.initialize();
 
       await plugin.moveArtifacts();
 
@@ -163,6 +167,7 @@ describe('Move Artifacts', () => {
   describe('service package', () => {
     it('should update the service package artifact base path to the serverless folder', async () => {
       const plugin = new EsbuildServerlessPlugin(mockServerlessConfig(packageService), mockOptions);
+      plugin.hooks.initialize();
 
       await plugin.moveArtifacts();
 


### PR DESCRIPTION
closes #334

Hey,

This PR ensures that the buildOptions is set in the initialize hook. 
https://www.serverless.com/framework/docs/guides/plugins/creating-plugins#lifecycle-events

As per their docs the previous method meant that the serverless object passed to `config()` had variables that were not resolved...
> Note: configuration values are only resolved after plugins are initialized. Do not try to read configuration in the plugin constructor, as variables aren't resolved yet. Read configuration in lifecycle events only.

## Considerations:
- I have removed the dependency on `memoizeWith` as now the buildOptions is only set once.  As the class field has not changed name or the returning value, no changes are required in any other file.