### PR TITLE
Remove buildOptions access before initialization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,8 +82,8 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     this.preLocal = preLocal.bind(this);
     this.bundle = bundle.bind(this);
 
-    this.outputWorkFolder = this.buildOptions.outputWorkFolder || WORK_FOLDER;
-    this.outputBuildFolder = this.buildOptions.outputBuildFolder || BUILD_FOLDER;
+    this.outputWorkFolder = this.outputWorkFolder || WORK_FOLDER;
+    this.outputBuildFolder = this.outputBuildFolder || BUILD_FOLDER;
 
     this.workDirPath = path.join(this.serviceDirPath, this.outputWorkFolder);
     this.buildDirPath = path.join(this.workDirPath, this.outputBuildFolder);


### PR DESCRIPTION
### Issue:
With the following settings in `serverless.yml`:
```yaml
custom:
  esbuild:
    packager: pnpm
    target: es2019
    minify: true
    bundle: true
 ```
 When running `serverless offline`, the offline server starts but when a file is changed, `serverless-esbuild` runs into an infinite loop and keeps compiling until the process is killed.
 
![image](https://user-images.githubusercontent.com/18052624/179718890-27fa49b6-e123-4c74-8a5e-ebdd8641846a.png)

### Investigation
 After some investigation, I found that [chikidar]([chokidar](https://github.com/floydspace/serverless-esbuild/blob/master/src/index.ts#L298)) is initialized with
```json
{
    "options": {
        "ignored": [
            null, // (1) 
            "dist",
            "node_modules",
            null, // (2)
            "node_modules/serverless-esbuild"
        ],
        "awaitWriteFinish": true,
        "ignoreInitial": true
    },
    "defaultPatterns": [
        "./**/*.(js|ts)"
    ]
}
```
Reading the code, `(1)`and `(2)` should actually be respectively `.esbuild` and `.build` since they are the default value from `serverless-esbuild` ([link](https://github.com/floydspace/serverless-esbuild#options)).

The issue is that `getCachedOptions` ran for the first time before `this.outputWorkFolder` and `this.outputBuildFolder` are defined. Hence the cache is populated with `null` instead.

### Fix
This fix, makes `this.outputWorkFolder` and `this.outputBuildFolder` initialized with the context value instead of the one from `getCachedOptions`.