### PR TITLE
fix: enable `esm` format

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [example folder](examples) for some example configurations.
 | `nativeZip`           | Uses the system's `zip` executable to create archives. _NOTE_: This will produce non-deterministic archives which causes a Serverless deployment update on every deploy.   | `false`                                             |
 | `outputBuildFolder`   | The output folder for Esbuild builds within the work folder.                                                                                                               | `'.build'`                                          |
 | `outputWorkFolder`    | The output folder for this plugin where all the bundle preparation is done.                                                                                                | `'.esbuild'`                                        |
-| `outputFileExtension` | The file extension used for the bundled output file. This will override the esbuild `outExtension` option               | `'.js'`                                        |
+| `outputFileExtension` | The file extension used for the bundled output file. This will override the esbuild `outExtension` option                                                                  | `'.js'`                                             |
 | `packagePath`         | Path to the `package.json` file for `external` dependency resolution.                                                                                                      | `'./package.json'`                                  |
 | `packager`            | Packager to use for `external` dependency resolution. Values: `npm`, `yarn`, `pnpm`                                                                                        | `'npm'`                                             |
 | `packagerOptions`     | Extra options for packagers for `external` dependency resolution.                                                                                                          | [Packager Options](#packager-options)               |
@@ -99,7 +99,7 @@ The following `esbuild` options are automatically set.
 | `entryPoints` | N/A        | Cannot be overridden                                                   |
 | `incremental` | N/A        | Cannot be overridden. Use `disableIncremental` to disable it           |
 | `outDir`      | N/A        | Cannot be overridden                                                   |
-| `platform`    | `'node'`   | Set to `'neutral'` to enable ESM support                               |
+| `platform`    | `'node'`   | Set `format` to `esm` to enable ESM support                            |
 | `target`      | `'node12'` | We dynamically set this. See [Supported Runtimes](#supported-runtimes) |
 | `watch`       | N/A        | Cannot be overridden                                                   |
 
@@ -147,11 +147,9 @@ custom:
 ```js
 // esbuild.config.js
 module.exports = (serverless) => ({
-  external: [
-    'lodash'
-  ],
-  plugins: []
-})
+  external: ['lodash'],
+  plugins: [],
+});
 ```
 
 ### Including Extra Files

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { uniq } from 'ramda';
 
 import EsbuildServerlessPlugin from '.';
+import { isESM } from './helper';
 import { FileBuildResult } from './types';
 import { trimExtension } from './utils';
 
@@ -27,22 +28,19 @@ export async function bundle(this: EsbuildServerlessPlugin, incremental = false)
     plugins: this.plugins,
   };
 
-  if (
-    this.buildOptions.platform === 'neutral' &&
-    this.buildOptions.outputFileExtension === '.cjs'
-  ) {
+  if (isESM(this.buildOptions) && this.buildOptions.outputFileExtension === '.cjs') {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore Serverless typings (as of v3.0.2) are incorrect
     throw new this.serverless.classes.Error(
-      'ERROR: platform "neutral" should not output a file with extension ".cjs".'
+      'ERROR: format "esm" or platform "neutral" should not output a file with extension ".cjs".'
     );
   }
 
-  if (this.buildOptions.platform === 'node' && this.buildOptions.outputFileExtension === '.mjs') {
+  if (!isESM(this.buildOptions) && this.buildOptions.outputFileExtension === '.mjs') {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore Serverless typings (as of v3.0.2) are incorrect
     throw new this.serverless.classes.Error(
-      'ERROR: platform "node" should not output a file with extension ".mjs".'
+      'ERROR: Non esm builds should not output a file with extension ".mjs".'
     );
   }
 

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -16,7 +16,7 @@ import {
 import semver from 'semver';
 import EsbuildServerlessPlugin from '.';
 import { ONLY_PREFIX, SERVERLESS_FOLDER } from './constants';
-import { doSharePath, flatDep, getDepsFromBundle } from './helper';
+import { doSharePath, flatDep, getDepsFromBundle, isESM } from './helper';
 import * as Packagers from './packagers';
 import { IFiles } from './types';
 import { humanSize, zip, trimExtension } from './utils';
@@ -176,7 +176,7 @@ export async function pack(this: EsbuildServerlessPlugin) {
       if (hasExternals) {
         const bundleDeps = getDepsFromBundle(
           path.join(this.buildDirPath, bundlePath),
-          this.buildOptions.platform
+          isESM(this.buildOptions)
         );
         const bundleExternals = intersection(bundleDeps, externals);
         depWhiteList = flatDep(packagerDependenciesList.dependencies, bundleExternals);

--- a/src/tests/bundle.test.ts
+++ b/src/tests/bundle.test.ts
@@ -334,7 +334,7 @@ describe('buildOption platform node', () => {
 
     const plugin = esbuildPlugin({ functionEntries, buildOptions: buildOptions as any });
 
-    const expectedError = 'ERROR: platform "node" should not output a file with extension ".mjs".';
+    const expectedError = 'ERROR: Non esm builds should not output a file with extension ".mjs".';
 
     try {
       await bundle.call(plugin);
@@ -496,7 +496,7 @@ describe('buildOption platform neutral', () => {
     const plugin = esbuildPlugin({ functionEntries, buildOptions: buildOptions as any });
 
     const expectedError =
-      'ERROR: platform "neutral" should not output a file with extension ".cjs".';
+      'ERROR: format "esm" or platform "neutral" should not output a file with extension ".cjs".';
 
     try {
       await bundle.call(plugin);


### PR DESCRIPTION
Recommend setting `format` to `esm` to enable ESM support. This PR enables us to recognise when we are in "ESM" mode or not.

Leaving the platform as `node` has its advantages.

eg. 

```
All [built-in node modules](https://nodejs.org/docs/latest/api/) such as fs are automatically marked as [external](https://esbuild.github.io/api/#external) so they don't cause errors when the bundler tries to bundle them.
```