### PR TITLE
fix: treat default packageJsonPath as relative

### DIFF
--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -238,7 +238,8 @@ export async function packExternalModules(this: EsbuildServerlessPlugin) {
   // get the local package.json by looking up until we hit a package.json file
   // if this is *not* a yarn workspace, it will be the same as rootPackageJsonPath
   const packageJsonPath =
-    this.buildOptions.packagePath || path.join(findUp('package.json'), './package.json');
+    this.buildOptions.packagePath ||
+    path.relative(process.cwd(), path.join(findUp('package.json'), './package.json'));
 
   // Determine and create packager
   const packager = await Packagers.get(this.buildOptions.packager);


### PR DESCRIPTION
When no `this.buildOptions.packagePath` is `undefined` the default `packageJsonPath` resolves to an absolute path.  This breaks later as `packageJsonPath` should be treated as relative.

https://github.com/floydspace/serverless-esbuild/pull/336#issuecomment-1190431132