### PR TITLE
refactor: asynchronously create packager instance

### DIFF
--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -1,5 +1,6 @@
-import fse from 'fs-extra';
 import path from 'path';
+
+import fse from 'fs-extra';
 import {
   compose,
   forEach,
@@ -24,11 +25,11 @@ import {
   without,
 } from 'ramda';
 
-import * as Packagers from './packagers';
-import { JSONObject } from './types';
+import { getPackager } from './packagers';
 import { findProjectRoot, findUp } from './utils';
 
-import EsbuildServerlessPlugin from './index';
+import type EsbuildServerlessPlugin from './index';
+import type { JSONObject } from './types';
 
 function rebaseFileReferences(pathToPackageRoot: string, moduleVersion: string) {
   if (/^(?:file:[^/]{2}|\.\/|\.\.\/)/.test(moduleVersion)) {
@@ -242,7 +243,7 @@ export async function packExternalModules(this: EsbuildServerlessPlugin) {
     path.relative(process.cwd(), path.join(findUp('package.json'), './package.json'));
 
   // Determine and create packager
-  const packager = await Packagers.get(this.buildOptions.packager);
+  const packager = await getPackager.call(this, this.buildOptions.packager);
 
   // Fetch needed original package.json sections
   const sectionNames = packager.copyPackageSectionNames;

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -1,6 +1,7 @@
+import path from 'path';
+
 import fs from 'fs-extra';
 import globby from 'globby';
-import path from 'path';
 import {
   intersection,
   isEmpty,
@@ -14,12 +15,14 @@ import {
   without,
 } from 'ramda';
 import semver from 'semver';
-import EsbuildServerlessPlugin from '.';
+
 import { ONLY_PREFIX, SERVERLESS_FOLDER } from './constants';
 import { doSharePath, flatDep, getDepsFromBundle, isESM } from './helper';
-import * as Packagers from './packagers';
-import { IFiles } from './types';
+import { getPackager } from './packagers';
 import { humanSize, zip, trimExtension } from './utils';
+
+import type EsbuildServerlessPlugin from './index';
+import type { IFiles } from './types';
 
 function setFunctionArtifactPath(this: EsbuildServerlessPlugin, func, artifactPath) {
   const version = this.serverless.getVersion();
@@ -137,7 +140,7 @@ export async function pack(this: EsbuildServerlessPlugin) {
   }
 
   // 2) If individually is set, we'll optimize files and zip per-function
-  const packager = await Packagers.get(this.buildOptions.packager);
+  const packager = await getPackager.call(this, this.buildOptions.packager);
 
   // get a list of every function bundle
   const buildResults = this.buildResults;

--- a/src/tests/packagers/index.test.ts
+++ b/src/tests/packagers/index.test.ts
@@ -1,0 +1,17 @@
+import { getPackager } from '../../packagers';
+
+import type EsbuildServerlessPlugin from '../../index';
+
+describe('getPackager()', () => {
+  const mockPlugin = {
+    log: {
+      debug: jest.fn(),
+    },
+  } as unknown as EsbuildServerlessPlugin;
+
+  it('Returns a Packager instance', async () => {
+    const npm = await getPackager.call(mockPlugin, 'npm');
+
+    expect(npm).toEqual(expect.any(Object));
+  });
+});

--- a/src/tests/type-predicate.test.ts
+++ b/src/tests/type-predicate.test.ts
@@ -1,0 +1,15 @@
+import { isPackagerId } from '../type-predicate';
+
+describe('isPackagerId()', () => {
+  it('Returns true for valid input', () => {
+    ['npm', 'pnpm', 'yarn'].forEach((id) => {
+      expect(isPackagerId(id)).toBeTruthy();
+    });
+  });
+
+  it('Returns false for invalid input', () => {
+    ['not-a-real-packager-id', false, 123, [], {}].forEach((id) => {
+      expect(isPackagerId(id)).toBeFalsy();
+    });
+  });
+});

--- a/src/type-predicate.ts
+++ b/src/type-predicate.ts
@@ -1,0 +1,5 @@
+import type { PackagerId } from './types';
+
+export function isPackagerId(input: unknown): input is PackagerId {
+  return input === 'npm' || input === 'pnpm' || input === 'yarn';
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import { BuildOptions, BuildResult, Plugin } from 'esbuild';
-import Serverless from 'serverless';
+import type { BuildOptions, BuildResult, Plugin } from 'esbuild';
+import type Serverless from 'serverless';
 
 export type ConfigFn = (sls: Serverless) => Configuration;
 
@@ -74,3 +74,5 @@ export interface IFile {
   readonly rootPath: string;
 }
 export type IFiles = readonly IFile[];
+
+export type PackagerId = 'npm' | 'pnpm' | 'yarn';


### PR DESCRIPTION
Rewrote instantiating a `Packager` to be asynchronous.

- correctly call it so that `this` is the correct plugin
- Packager instance is memoized