### PR TITLE
fix: allow esbuild versions < 0.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "node": ">=12"
       },
       "peerDependencies": {
-        "esbuild": ">=0.8 <0.15"
+        "esbuild": ">=0.8 <0.16"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "semver": "^7.3.5"
   },
   "peerDependencies": {
-    "esbuild": ">=0.8 <0.15"
+    "esbuild": ">=0.8 <0.16"
   },
   "lint-staged": {
     "*.ts": [


### PR DESCRIPTION
Resolves #360 

Might need to do some changes to support yarn pnp and pnpm but otherwise we should let consumers keep up to date.
