### PR TITLE
feat: add nodeExternals configuration for esbuild-node-external plugin

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -62,6 +62,7 @@ export async function bundle(this: EsbuildServerlessPlugin, incremental = false)
   delete config['outputFileExtension'];
   delete config['outputBuildFolder'];
   delete config['outputWorkFolder'];
+  delete config['nodeExternals'];
 
   /** Build the files */
   const bundleMapper = async (entry: string): Promise<FileBuildResult> => {

--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -213,10 +213,15 @@ export async function packExternalModules(this: EsbuildServerlessPlugin) {
     fse.existsSync(path.resolve(__dirname, '../../esbuild-node-externals/dist/utils.js'))
   ) {
     const { findDependencies, findPackagePaths } = require('esbuild-node-externals/dist/utils');
+
+    const allowList = this.buildOptions?.nodeExternals?.allowList
+      ? this.buildOptions.nodeExternals.allowList
+      : [];
+
     this.buildOptions.external = findDependencies({
       dependencies: true,
       packagePaths: findPackagePaths(),
-      allowList: [],
+      allowList,
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,10 @@ export interface PackagerOptions {
   scripts?: string[] | string;
 }
 
+interface NodeExternalsOptions {
+  allowList?: string[];
+}
+
 export type EsbuildOptions = Omit<BuildOptions, 'nativeZip' | 'watch' | 'plugins'>;
 
 export interface Configuration extends EsbuildOptions {
@@ -32,6 +36,7 @@ export interface Configuration extends EsbuildOptions {
   outputWorkFolder?: string;
   outputBuildFolder?: string;
   outputFileExtension: '.js' | '.cjs' | '.mjs';
+  nodeExternals?: NodeExternalsOptions;
 }
 
 export interface FunctionEntry {


### PR DESCRIPTION
Add configuration option `nodeExternals` which allows to pass `allowList` array for the `esbuild-node-externals` plugin.

This intends to solve https://github.com/floydspace/serverless-esbuild/issues/250