### PR TITLE
Support Linking External Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Serverless plugin for zero-config JavaScript and TypeScript code bundling using 
 - [Advanced Configuration](#advanced-configuration)
   - [Including Extra Files](#including-extra-files)
   - [External Dependencies](#external-dependencies)
+  - [Linking External Dependencies](#linking-external-dependencies)
   - [Esbuild Plugins](#esbuild-plugins)
 - [Usage](#usage)
   - [Automatic Compilation](#automatic-compilation)
@@ -88,6 +89,7 @@ See [example folder](examples) for some example configurations.
 | `packager`            | Packager to use for `external` dependency resolution. Values: `npm`, `yarn`, `pnpm`                                                                                        | `'npm'`                                             |
 | `packagerOptions`     | Extra options for packagers for `external` dependency resolution.                                                                                                          | [Packager Options](#packager-options)               |
 | `watch`               | Watch options for `serverless-offline`.                                                                                                                                    | [Watch Options](#watch-options)                     |
+| `link`                | An array of `external` dependencies to link into the Lambda. The list is passed to the `link` command for the `packager` listed above.                                     | `[]`                                                |
 
 #### Default Esbuild Options
 
@@ -185,6 +187,19 @@ custom:
     external:
       - 'my-package-name'
       - 'another-package-name'
+```
+
+### Linking External Dependencies
+
+As stated above in the [External Dependencies](#external-dependencies) section, some dependencies will be installed and included with your build under `node_modules`. If you wish to link some or all of these dependencies into your Lambda rather than install them, you can utilize the `link` option.
+
+```yml
+custom:
+  esbuild:
+    external:
+      - lodash
+    link:
+      - lodash
 ```
 
 ### Esbuild Plugins

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -61,6 +61,7 @@ export async function bundle(this: EsbuildServerlessPlugin, incremental = false)
   delete config['outputBuildFolder'];
   delete config['outputWorkFolder'];
   delete config['nodeExternals'];
+  delete config['link'];
 
   /** Build the files */
   const bundleMapper = async (entry: string): Promise<FileBuildResult> => {

--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -312,6 +312,13 @@ export async function packExternalModules(this: EsbuildServerlessPlugin) {
   await packager.install(compositeModulePath, installExtraArgs, exists);
   this.log.debug(`Package took [${Date.now() - start} ms]`);
 
+  if (this.buildOptions.link?.length) {
+    const startLink = Date.now();
+    this.log.verbose('Linking external modules: ' + this.buildOptions.link.join(', '));
+    await packager.link(compositeModulePath, this.buildOptions.link);
+    this.log.debug(`Linking took [${Date.now() - startLink} ms]`);
+  }
+
   // Prune extraneous packages - removes not needed ones
   const startPrune = Date.now();
   await packager.prune(compositeModulePath);

--- a/src/packagers/npm.ts
+++ b/src/packagers/npm.ts
@@ -262,6 +262,14 @@ export class NPM implements Packager {
     await spawnProcess(command, args, { cwd });
   }
 
+  async link(cwd: string, packages: string[] = []) {
+    const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
+
+    for (const pkg of packages) {
+      await spawnProcess(command, ['link', pkg], { cwd });
+    }
+  }
+
   async prune(cwd) {
     const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
     const args = ['prune'];

--- a/src/packagers/packager.ts
+++ b/src/packagers/packager.ts
@@ -7,6 +7,7 @@ export interface Packager {
   getProdDependencies(cwd: string, depth?: number): Promise<DependenciesResult>;
   rebaseLockfile(pathToPackageRoot: string, lockfile: JSONObject): JSONObject;
   install(cwd: string, extraArgs: Array<string>, useLockfile?: boolean): Promise<void>;
+  link(cwd: string, packages: string[]): Promise<void>;
   prune(cwd: string): Promise<void>;
   runScripts(cwd: string, scriptNames): Promise<void>;
 }

--- a/src/packagers/pnpm.ts
+++ b/src/packagers/pnpm.ts
@@ -100,6 +100,16 @@ export class Pnpm implements Packager {
     await spawnProcess(command, args, { cwd });
   }
 
+  async link(cwd: string, packages: string[] = []) {
+    const command = /^win/.test(process.platform) ? 'pnpm.cmd' : 'pnpm';
+
+    for (const pkg of packages) {
+      const args = pkg.startsWith('.') ? ['link', pkg] : ['link', '--global', pkg];
+
+      await spawnProcess(command, args, { cwd });
+    }
+  }
+
   async prune(cwd) {
     const command = /^win/.test(process.platform) ? 'pnpm.cmd' : 'pnpm';
     const args = ['prune'];

--- a/src/packagers/yarn.ts
+++ b/src/packagers/yarn.ts
@@ -205,6 +205,14 @@ export class Yarn implements Packager {
     await spawnProcess(command, args, { cwd });
   }
 
+  async link(cwd: string, packages: string[] = []) {
+    const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
+
+    const args = ['link', ...packages];
+
+    await spawnProcess(command, args, { cwd });
+  }
+
   // "Yarn install" prunes automatically
   prune(cwd) {
     return this.install(cwd, []);

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface Configuration extends EsbuildOptions {
   outputBuildFolder?: string;
   outputFileExtension: '.js' | '.cjs' | '.mjs';
   nodeExternals?: NodeExternalsOptions;
+  link?: string[];
 }
 
 export interface FunctionEntry {


### PR DESCRIPTION
Currently, when specifying external dependencies, either manually or through `esbuild-node-externals`, there is no capability to link external dependencies to the project. This functionality is critical for applications where active development includes creating and maintaining multiple external packages. 

Support for linking external dependencies has been added through a new configuration property called `link`, which will accept an array of packages and, using the specified `packager` link the packages into the `node_modules` folder nestled in the `.esbuild` directory. 
