### PR TITLE
feat: allows .jsx and .tsx as valid handler extensions

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -49,7 +49,7 @@ export function extractFunctionEntries(
     // replace only last instance to allow the same name for file and handler
     const fileName = h.substring(0, fnNameLastAppearanceIndex);
 
-    const extensions = ['.ts', '.js'];
+    const extensions = ['.ts', '.js', '.jsx', '.tsx'];
     for (const extension of extensions) {
       // Check if the .{extension} files exists. If so return that to watch
       if (fs.existsSync(path.join(cwd, fileName + extension))) {


### PR DESCRIPTION
### This PR adds `.jsx` and `.tsx` as valid extensions to the `extractFunctionEntries` helper method.

My organization uses .jsx/.tsx serverless handlers to generate and send emails using react-dom/server renderToStaticMarkup. However, serverless-esbuild cannot find our handlers, because it is only checking for `.js` and `.ts` files.