### PR TITLE
fix: node18 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ AWS:
 
 | Runtime      | Target   |
 | ------------ | -------- |
+| `nodejs18.x` | `node18` |
 | `nodejs16.x` | `node16` |
 | `nodejs14.x` | `node14` |
 | `nodejs12.x` | `node12` |

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -168,6 +168,7 @@ export const doSharePath = (child, parent) => {
 
 export const providerRuntimeMatcher = Object.freeze({
   aws: {
+    'nodejs18.x': 'node18',
     'nodejs16.x': 'node16',
     'nodejs14.x': 'node14',
     'nodejs12.x': 'node12',


### PR DESCRIPTION
🎉  https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/