### PR TITLE
refactor: node externals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@typescript-eslint/eslint-plugin": "^5.34.0",
         "@typescript-eslint/parser": "^5.34.0",
         "esbuild": "^0.15.9",
+        "esbuild-node-externals": "^1.5.0",
         "eslint": "^8.20.0",
         "husky": "^8.0.1",
         "jest": "^29.0.3",
@@ -3901,6 +3902,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/esbuild-node-externals": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esbuild-node-externals/-/esbuild-node-externals-1.5.0.tgz",
+      "integrity": "sha512-9394Ne2t2Z243BWeNBRkXEYVMOVbQuzp7XSkASZTOQs0GSXDuno5aH5OmzEXc6GMuln5zJjpkZpgwUPW0uRKgw==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "5.0.0",
+        "tslib": "2.3.1"
+      },
+      "peerDependencies": {
+        "esbuild": "0.12 - 0.15"
+      }
+    },
+    "node_modules/esbuild-node-externals/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
     },
     "node_modules/esbuild-openbsd-64": {
       "version": "0.15.9",
@@ -14676,6 +14696,24 @@
       "integrity": "sha512-yWgxaYTQz+TqX80wXRq6xAtb7GSBAp6gqLKfOdANg9qEmAI1Bxn04IrQr0Mzm4AhxvGKoHzjHjMgXbCCSSDxcw==",
       "dev": true,
       "optional": true
+    },
+    "esbuild-node-externals": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esbuild-node-externals/-/esbuild-node-externals-1.5.0.tgz",
+      "integrity": "sha512-9394Ne2t2Z243BWeNBRkXEYVMOVbQuzp7XSkASZTOQs0GSXDuno5aH5OmzEXc6GMuln5zJjpkZpgwUPW0uRKgw==",
+      "dev": true,
+      "requires": {
+        "find-up": "5.0.0",
+        "tslib": "2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
     },
     "esbuild-openbsd-64": {
       "version": "0.15.9",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@typescript-eslint/eslint-plugin": "^5.34.0",
     "@typescript-eslint/parser": "^5.34.0",
     "esbuild": "^0.15.9",
+    "esbuild-node-externals": "^1.5.0",
     "eslint": "^8.20.0",
     "husky": "^8.0.1",
     "jest": "^29.0.3",
@@ -93,7 +94,13 @@
     "typescript": "^4.8.3"
   },
   "peerDependencies": {
-    "esbuild": ">=0.8 <0.16"
+    "esbuild": ">=0.8 <0.16",
+    "esbuild-node-externals": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "esbuild-node-externals": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
- Added `esbuild-node-externals` as a dev dependency and optional peer dependency
  - This allows us to use the types from their package during development.
- Refactored how `esbuild-node-externals/dist/utils` was being detected.
  - `require.resolve()` is now used instead of a hard coded relative path.