### PR TITLE
Look up root workspace package.json for dependencies when using externals

### DIFF
--- a/src/pack-externals.ts
+++ b/src/pack-externals.ts
@@ -274,9 +274,15 @@ export async function packExternalModules(this: EsbuildServerlessPlugin) {
 
   // (1) Generate dependency composition
   const externalModules = map((external) => ({ external }), externals);
-  const compositeModules: JSONObject = uniq(
+  let compositeModules: JSONObject = uniq(
     getProdModules.call(this, externalModules, packageJsonPath, rootPackageJsonPath)
   );
+
+  if (isWorkspace) {
+    compositeModules = compositeModules.concat(
+      getProdModules.call(this, externalModules, rootPackageJsonPath, rootPackageJsonPath)
+    );
+  }
 
   if (isEmpty(compositeModules)) {
     // The compiled code does not reference any external modules at all


### PR DESCRIPTION
The current logic of the plugin when using the `external:` option is to look if the dependencies specified in it are also in package.json `dependencies` or `devDependencies` and to ignore if not found there.

However in a monorepo setup, it is common to have shared dependencies in the root package.json and these might be wanted to be in external for whatever reason (in our use-case, we have a monorepo with lambdas sharing common dependencies such as `aws-sdk`, that need to be required instead of being bundled for calls intercepting by OpenTelemetry/Dynatrace)

This PR updates `getProdModules` to also lookup the root `package.json` in addition to the package `package.json` when looking for dependencies using `externals:`

This fix  solved the issue in our setup, but we might be have not enough insight for all use-cases, we will happily update this MR if some additional logic is needed.