### PR TITLE
feat: add support for dir/index handlers

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -77,6 +77,13 @@ export function extractFunctionEntries(
           func,
           functionAlias,
         };
+      } else if (fs.existsSync(path.join(cwd, path.join(fileName, 'index') + extension))) {
+        const entry = path.relative(cwd, path.join(fileName, 'index') + extension);
+        return {
+          entry: os.platform() === 'win32' ? entry.replace(/\\/g, '/') : entry,
+          func,
+          functionAlias,
+        };
       }
     }
 

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
-import path from 'path';
 import os from 'os';
+import path from 'path';
 
 import { extractFunctionEntries, flatDep, getDepsFromBundle, isESM } from '../helper';
 
@@ -41,6 +41,38 @@ describe('extractFunctionEntries', () => {
         },
         {
           entry: 'file2.ts',
+          func: functionDefinitions['function2'],
+          functionAlias: 'function2',
+        },
+      ]);
+    });
+
+    it('should return entries for handlers which reference directories that contain index files', () => {
+      jest.mocked(fs.existsSync).mockImplementation((fPath) => {
+        return typeof fPath !== 'string' || fPath.endsWith('/index.ts');
+      });
+
+      const functionDefinitions = {
+        function1: {
+          events: [],
+          handler: 'dir1.handler',
+        },
+        function2: {
+          events: [],
+          handler: 'dir2.handler',
+        },
+      };
+
+      const fileNames = extractFunctionEntries(cwd, 'aws', functionDefinitions);
+
+      expect(fileNames).toStrictEqual([
+        {
+          entry: 'dir1/index.ts',
+          func: functionDefinitions['function1'],
+          functionAlias: 'function1',
+        },
+        {
+          entry: 'dir2/index.ts',
           func: functionDefinitions['function2'],
           functionAlias: 'function2',
         },


### PR DESCRIPTION
Adds code (and a test) that searches for the handler file as an `index.[js|ts|tsx|jsx]`. This way one can point to a directory with an index file that exports the handler function, instead of requiring the author to name the exact file that exports the handler.

Directory structure:

```
- handlers
  - foo
    - index.ts
```

`serverless.yml`:

```
# ...
functions:
  foo:
    handler: handlers/foo.foo
```