### PR TITLE
fix: get rid of harmful shadow variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,9 +210,9 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     }
 
     for (const fn of Object.values(this.functions)) {
-      const patterns = asArray(fn.package?.patterns).filter(isString);
+      const fnPatterns = asArray(fn.package?.patterns).filter(isString);
 
-      for (const pattern of patterns) {
+      for (const pattern of fnPatterns) {
         if (pattern.startsWith('!')) {
           ignored.push(pattern.slice(1));
         } else {


### PR DESCRIPTION
fixes #415

@webdeveric there was a `patterns` array that was shadowed and led to stack overflow apparently.