### PR TITLE
feat: add skipEsbuild option on a per function level

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ The following `esbuild` options are automatically set.
 | `pattern` | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to respond to | `./\*_/_.(js\|ts)` (watches all `.js` and `.ts` files) |
 | `ignore`  | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to ignore     | `'.esbuild', 'dist', 'node_modules', '.build']`        |
 
+#### Function Options
+
+| Option        | Description                                                          | Default     |
+| ------------- | -------------------------------------------------------------------- | ----------- |
+| `skipEsbuild` | Set this property to `true` on a function definition to skip esbuild | `undefined` |
+
 ## Supported Runtimes
 
 This plugin will automatically set the esbuild `target` for the following supported Serverless runtimes

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,15 @@ import { preOffline } from './pre-offline';
 import { preLocal } from './pre-local';
 import { bundle } from './bundle';
 import { BUILD_FOLDER, ONLY_PREFIX, SERVERLESS_FOLDER, WORK_FOLDER } from './constants';
-import type { ConfigFn, Configuration, FileBuildResult, FunctionBuildResult, Plugins, ReturnPluginsFn } from './types';
+import type {
+  ConfigFn,
+  Configuration,
+  EsbuildFunctionDefinitionHandler,
+  FileBuildResult,
+  FunctionBuildResult,
+  Plugins,
+  ReturnPluginsFn,
+} from './types';
 
 function updateFile(op: string, src: string, dest: string) {
   if (['add', 'change', 'addDir'].includes(op)) {
@@ -95,6 +103,14 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     this.preOffline = preOffline.bind(this);
     this.preLocal = preLocal.bind(this);
     this.bundle = bundle.bind(this);
+
+    // This tells serverless that this skipEsbuild property can exist in a function definition, but isn't required.
+    // That way a user could skip a function if they have defined their own artifact, for example.
+    this.serverless.configSchemaHandler.defineFunctionProperties(this.serverless.service.provider.name, {
+      properties: {
+        skipEsbuild: { type: 'boolean' },
+      },
+    });
 
     this.hooks = {
       initialize: () => this.init(),
@@ -187,7 +203,11 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     const nodeFunctions: Record<string, Serverless.FunctionDefinitionHandler> = {};
 
     for (const [functionAlias, fn] of Object.entries(functions)) {
-      if (this.isFunctionDefinitionHandler(fn) && this.isNodeFunction(fn)) {
+      if (
+        this.isFunctionDefinitionHandler(fn) &&
+        this.isNodeFunction(fn) &&
+        !(fn as EsbuildFunctionDefinitionHandler).skipEsbuild
+      ) {
         nodeFunctions[functionAlias] = fn;
       }
     }

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -54,6 +54,14 @@ const mockServerlessConfig = (serviceOverride?: Partial<Service>): Serverless =>
     config: {
       servicePath: '/workDir',
     },
+    configSchemaHandler: {
+      defineCustomProperties: jest.fn(),
+      defineFunctionEvent: jest.fn(),
+      defineFunctionEventProperties: jest.fn(),
+      defineFunctionProperties: jest.fn(),
+      defineProvider: jest.fn(),
+      defineTopLevelProperty: jest.fn(),
+    },
     cli: mockCli,
   } as Partial<Serverless> as Serverless;
 };
@@ -143,6 +151,41 @@ describe('Move Artifacts', () => {
         mockOptions
       );
 
+      plugin.hooks.initialize?.();
+
+      await plugin.moveArtifacts();
+
+      expect(plugin.functions).toMatchInlineSnapshot(`
+        {
+          "hello1": {
+            "events": [],
+            "handler": "hello1.handler",
+            "package": {
+              "artifact": ".serverless/hello1",
+            },
+          },
+          "hello2": {
+            "events": [],
+            "handler": "hello2.handler",
+            "package": {
+              "artifact": ".serverless/hello2",
+            },
+          },
+        }
+      `);
+    });
+
+    it('should skip function if skipEsbuild is set to true', async () => {
+      const hello3 = { handler: 'hello3.handler', events: [], skipEsbuild: true };
+      const plugin = new EsbuildServerlessPlugin(
+        mockServerlessConfig({
+          functions: {
+            ...packageIndividuallyService.functions,
+            hello3,
+          },
+        }),
+        mockOptions
+      );
       plugin.hooks.initialize?.();
 
       await plugin.moveArtifacts();

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,10 @@ export interface Configuration extends EsbuildOptions {
   nodeExternals?: NodeExternalsOptions;
 }
 
+export interface EsbuildFunctionDefinitionHandler extends Serverless.FunctionDefinitionHandler {
+  skipEsbuild: boolean;
+}
+
 export interface FunctionEntry {
   entry: string;
   func: Serverless.FunctionDefinitionHandler | null;


### PR DESCRIPTION
### Use case:

I've got multiple projects where I'm using serverless-esbuild and it's working great. But I'm building my own custom plugin for these projects where I'm adding a function and defining my own artifact zip file. Turns out though, serverless-esbuild will try to run esbuild even if an artifact is already defined. I'm sure this use case wasn't something that was thought of in the beginning, but I feel like it's something this should account for. 

This has also been brought up in #376

### Solution:

I tried going a variety of different routes, but the best solution I have so far is to make it so you can set a property when you define the function called `skipEsbuild` and if it's `true`, then it'll just skip over it. I'm leveraging the [Serverless schema configuration helpers](https://www.serverless.com/framework/docs/guides/plugins/custom-configuration) so that some default validation takes place.

I'm still pretty new to TypeScript and all, so if I did something incorrect here, let me know!