### PR TITLE
feat: support installing with Yarn berry flags

### DIFF
--- a/src/tests/packagers/yarn.test.ts
+++ b/src/tests/packagers/yarn.test.ts
@@ -240,4 +240,20 @@ describe('Yarn Packager', () => {
     await expect(yarnWithoutInstall.install(path, [], false)).resolves.toBeUndefined();
     expect(spawnSpy).toBeCalledTimes(0);
   });
+
+  it('should install with the Yarn berry lockfile flags if the current yarn version is >=2', async () => {
+    // Mock first call for getting Yarn version
+    spawnSpy
+      .mockResolvedValueOnce({
+        stderr: '',
+        stdout: '3.1.0',
+      })
+      .mockResolvedValueOnce({
+        stderr: '',
+        stdout: '',
+      });
+
+    await expect(yarn.install(path, [], true)).resolves.toBeUndefined();
+    expect(spawnSpy).toHaveBeenNthCalledWith(2, 'yarn', ['install', '--immutable'], { cwd: './' });
+  });
 });


### PR DESCRIPTION
In addition to the `noInstall` flagged added in PR #421, I have an additional use case where I still need to let `serverless-esbuild` proceed with the install in a Yarn 3 app. As such, I have brought over the Yarn Berry (>= 2) install method from `serverless-webpack`, as appropriate for `serverless-esbuild`. In effect it conditionally adds the appropriate install flags depending on the existing `useLockfile` flag, and the Yarn version (determined by two new methods).

_The implementation here is copied almost wholesale from the `serverless-webpack` implementation, here: https://github.com/serverless-heaven/serverless-webpack/blob/master/lib/packagers/yarn.js#L139_