### PR TITLE
fix: remove ! from exclusion pattern list for proper matching

### DIFF
--- a/src/pack.ts
+++ b/src/pack.ts
@@ -177,7 +177,9 @@ export async function pack(this: EsbuildServerlessPlugin) {
 
       assert(func.package?.patterns);
 
-      const functionExclusionPatterns = func.package.patterns.filter((pattern) => pattern.charAt(0) === '!');
+      const functionExclusionPatterns = func.package.patterns
+        .filter((pattern) => pattern.charAt(0) === '!')
+        .map((pattern) => pattern.slice(1));
 
       const functionFiles = await globby(func.package.patterns, { cwd: buildDirPath });
       const functionExcludedFiles = (await globby(functionExclusionPatterns, { cwd: buildDirPath })).map(trimExtension);


### PR DESCRIPTION
My last PR (#428) had a small boolean logic error, by grabbing all the exclude patterns and then simply running globby on them, we were effectively gathering nothing, rendering the change ineffectual.  In order to properly gather the list of files to exclude, we need to remove the `!` from the exclusion patterns so we can actually get the results we want from globby.