### PR TITLE
fix: external incompatibility with Yarn 2+; conditionally set packager args

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ The following `esbuild` options are automatically set.
 
 #### Packager Options
 
-| Option    | Description                                                                                           | Default     |
-| --------- | ----------------------------------------------------------------------------------------------------- | ----------- |
-| `scripts` | A string or array of scripts to be executed, currently only supports 'scripts' for npm, pnpm and yarn | `undefined` |
-| `noInstall` | [Yarn only] A boolean that deactivates the install step | `false` |
+| Option           | Description                                                                                                                                                                        | Default     |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `scripts`        | A string or array of scripts to be executed, currently only supports 'scripts' for npm, pnpm and yarn                                                                              | `undefined` |
+| `noInstall`      | [Yarn only] A boolean that deactivates the install step                                                                                                                            | `false`     |
+| `ignoreLockfile` | [Yarn only] A boolean to bypass lockfile validation, typically paired with `external` dependencies because we generate a new package.json with only the externalized dependencies. | `false`     |
 
 #### Watch Options
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       packager: 'npm',
       packagerOptions: {
         noInstall: false,
+        ignoreLockfile: false,
       },
       installExtraArgs: [],
       watch: {

--- a/src/packagers/yarn.ts
+++ b/src/packagers/yarn.ts
@@ -242,11 +242,12 @@ export class Yarn implements Packager {
       return;
     }
 
+    const version = await this.getVersion(cwd);
     const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
 
     const args = useLockfile
-      ? ['install', '--frozen-lockfile', '--non-interactive', ...extraArgs]
-      : ['install', '--non-interactive', ...extraArgs];
+      ? ['install', ...(version.isBerry ? ['--immutable'] : ['--frozen-lockfile', '--non-interactive']), ...extraArgs]
+      : ['install', ...(version.isBerry ? [] : ['--non-interactive']), ...extraArgs];
 
     await spawnProcess(command, args, { cwd });
   }

--- a/src/packagers/yarn.ts
+++ b/src/packagers/yarn.ts
@@ -237,7 +237,7 @@ export class Yarn implements Packager {
     );
   }
 
-  async install(cwd: string, extraArgs: Array<string>, useLockfile = true) {
+  async install(cwd: string, extraArgs: Array<string>, hasLockfile = true) {
     if (this.packagerOptions.noInstall) {
       return;
     }
@@ -245,9 +245,10 @@ export class Yarn implements Packager {
     const version = await this.getVersion(cwd);
     const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
 
-    const args = useLockfile
-      ? ['install', ...(version.isBerry ? ['--immutable'] : ['--frozen-lockfile', '--non-interactive']), ...extraArgs]
-      : ['install', ...(version.isBerry ? [] : ['--non-interactive']), ...extraArgs];
+    const args =
+      !this.packagerOptions.ignoreLockfile && hasLockfile
+        ? ['install', ...(version.isBerry ? ['--immutable'] : ['--frozen-lockfile', '--non-interactive']), ...extraArgs]
+        : ['install', ...(version.isBerry ? [] : ['--non-interactive']), ...extraArgs];
 
     await spawnProcess(command, args, { cwd });
   }

--- a/src/packagers/yarn.ts
+++ b/src/packagers/yarn.ts
@@ -57,6 +57,18 @@ export class Yarn implements Packager {
     return false;
   }
 
+  async getVersion(cwd: string) {
+    const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
+    const args = ['-v'];
+
+    const output = await spawnProcess(command, args, { cwd });
+
+    return {
+      version: output.stdout,
+      isBerry: parseInt(output.stdout.charAt(0), 10) > 1,
+    };
+  }
+
   async getProdDependencies(cwd: string, depth?: number): Promise<DependenciesResult> {
     const command = /^win/.test(process.platform) ? 'yarn.cmd' : 'yarn';
     const args = ['list', depth ? `--depth=${depth}` : null, '--json', '--production'].filter(isString);

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface WatchConfiguration {
 export interface PackagerOptions {
   scripts?: string[] | string;
   noInstall?: boolean;
+  ignoreLockfile?: boolean;
 }
 
 interface NodeExternalsOptions {


### PR DESCRIPTION
As a result of my issue filed in #435, we can detect the version of Yarn being used by the user and set the appropriate packager args.
* `--non-interactive` was removed from Yarn 2+
* `--frozen-lockfile` was changed to `--immutable` in Yarn 2+
* However, because of the new nature of Yarn `--immutable`, if you are using `external` dependencies the lockfile will always fail because we generate a new package.json with only the externalized dependencies. Therefore, I added `ignoreLockfile` as a Yarn only packagerOption to bypass this.

Closes #435 #433