### PR TITLE
Allow overriding chokidar options

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ The following `esbuild` options are automatically set.
 
 #### Watch Options
 
-| Option    | Description                                                                                          | Default                                                |
-| --------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `pattern` | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to respond to | `./\*_/_.(js\|ts)` (watches all `.js` and `.ts` files) |
-| `ignore`  | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to ignore     | `'.esbuild', 'dist', 'node_modules', '.build']`        |
+| Option    | Description                                                                                          | Default                                               |
+| --------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `pattern` | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to respond to | `./**/*.(js\|ts)` (watches all `.js` and `.ts` files) |
+| `ignore`  | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to ignore     | `['.esbuild', 'dist', 'node_modules', '.build']`      |
 
 #### Function Options
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The following `esbuild` options are automatically set.
 | ---------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | `pattern`  | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to respond to | `./**/*.(js\|ts)` (watches all `.js` and `.ts` files) |
 | `ignore`   | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to ignore     | `['.esbuild', 'dist', 'node_modules', '.build']`      |
-| `chokidar` | Any [Chokidar option](https://github.com/paulmillr/chokidar#api)                                     | `{ awaitWriteFinish: true, ignoreInitial: true }`     |
+| `chokidar` | Any [Chokidar option](https://github.com/paulmillr/chokidar#api)                                     | `{ ignoreInitial: true }`                             |
 
 #### Function Options
 

--- a/README.md
+++ b/README.md
@@ -112,10 +112,11 @@ The following `esbuild` options are automatically set.
 
 #### Watch Options
 
-| Option    | Description                                                                                          | Default                                               |
-| --------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `pattern` | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to respond to | `./**/*.(js\|ts)` (watches all `.js` and `.ts` files) |
-| `ignore`  | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to ignore     | `['.esbuild', 'dist', 'node_modules', '.build']`      |
+| Option     | Description                                                                                          | Default                                               |
+| ---------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `pattern`  | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to respond to | `./**/*.(js\|ts)` (watches all `.js` and `.ts` files) |
+| `ignore`   | An [anymatch-compatible definition](https://github.com/es128/anymatch) for the watcher to ignore     | `['.esbuild', 'dist', 'node_modules', '.build']`      |
+| `chokidar` | Any [Chokidar option](https://github.com/paulmillr/chokidar#api)                                     | `{ awaitWriteFinish: true, ignoreInitial: true }`     |
 
 #### Function Options
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import globby from 'globby';
 
-import { concat, mergeRight } from 'ramda';
+import { concat, mergeDeepRight } from 'ramda';
 import type Serverless from 'serverless';
 import type ServerlessPlugin from 'serverless/classes/Plugin';
 import chokidar from 'chokidar';
@@ -296,8 +296,8 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     const resolvedOptions = {
       ...(target ? { target } : {}),
     };
-    const withDefaultOptions = mergeRight(DEFAULT_BUILD_OPTIONS);
-    const withResolvedOptions = mergeRight(withDefaultOptions(resolvedOptions));
+    const withDefaultOptions = mergeDeepRight(DEFAULT_BUILD_OPTIONS);
+    const withResolvedOptions = mergeDeepRight(withDefaultOptions(resolvedOptions));
 
     const configPath: string | undefined = this.serverless.service.custom?.esbuild?.config;
 
@@ -305,7 +305,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
 
     return withResolvedOptions<Configuration>(
       config ? config(this.serverless) : this.serverless.service.custom?.esbuild ?? {}
-    );
+    ) as Configuration;
   }
 
   get functionEntries() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,7 +278,6 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
         pattern: './**/*.(js|ts)',
         ignore: [WORK_FOLDER, 'dist', 'node_modules', BUILD_FOLDER],
         chokidar: {
-          awaitWriteFinish: true,
           ignoreInitial: true,
         },
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { WatchOptions } from 'chokidar';
 import type { BuildOptions, BuildResult, Plugin } from 'esbuild';
 import type Serverless from 'serverless';
 
@@ -9,6 +10,7 @@ export type ReturnPluginsFn = (sls: Serverless) => Plugins;
 export interface WatchConfiguration {
   pattern?: string[] | string;
   ignore?: string[] | string;
+  chokidar?: WatchOptions;
 }
 
 export interface PackagerOptions {


### PR DESCRIPTION
This adds support for overriding chokidar options by setting them under the watch section of the options. This is useful because the appropriate value for `awaitWriteFinish` is dependent on the OS and hardware.

I also removed setting `awaitWriteFinish` by default as I don't think it's a good idea as I explain in the commit message. Though, if you disagree with this, I'd rather get the rest of the PR merged without that than nothing at all, so I at least can unset it myself.

I also changed the options to be deeply merged, because otherwise you have to set all the default values under a section if you set a value in it. E.g. if you set anything under watch, you had to specify patterns as well, otherwise nothing is watched. With a deep merge, only the specific options you set are overridden.

Fixes #290