### PR TITLE
fix: don't dispose build contexts

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -161,10 +161,5 @@ export async function bundle(this: EsbuildServerlessPlugin, incremental = false)
     })
     .filter((result): result is FunctionBuildResult => typeof result === 'object');
 
-  // dispose of long-running build contexts
-  Object.entries(this.buildCache).forEach((entry) => {
-    entry[1].context?.dispose();
-  });
-
   this.log.verbose('Compiling completed.');
 }


### PR DESCRIPTION
Previously the build results were stored in a cache, but the context was immediately disposed. This caused an error because the context object was still in the cache, so when rebuilding it tried to call .rebuild() on the context on line 97 which threw an exception because you can't call rebuild on disposed contexts.

I don't get why contexts are stored in a cache and tried rebuilding on if they are disposed, so I removed disposing them all together. If they should still be disposed, the context needs to be completely removed, so it doesn't try calling rebuild on it.

Fixes #439