### PR TITLE
feat: adds support for `serverless-azure-functions` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ The following `esbuild` options are automatically set.
 
 ## Supported Runtimes
 
-This plugin will automatically set the esbuild `target` for the following supported Serverless runtimes
+This plugin will automatically set the esbuild `target` for the following supported Serverless runtimes:
 
-AWS:
+###AWS 
 
 | Runtime      | Target   |
 | ------------ | -------- |
@@ -136,6 +136,26 @@ AWS:
 | `nodejs16.x` | `node16` |
 | `nodejs14.x` | `node14` |
 | `nodejs12.x` | `node12` |
+
+### Azure
+
+This plugin is compatible with the [serverless-azure-functions](https://github.com/serverless/serverless-azure-functions) plugin, and will set the runtimes accordingly.
+
+| Runtime      | Target   |
+| ------------ | -------- |
+| `nodejs18`   | `node18` |
+| `nodejs16`   | `node16` |
+| `nodejs14`   | `node14` |
+| `nodejs12`   | `node12` |
+
+**Please Note** When using this package in conjunction with the `serverless-azure-functions` plugin, the following additional configuration is required to ensure function apps are built correctly:
+
+```yml
+package:
+	patterns: ["host.json", "**/function.json"],
+```
+
+### Non-Node functions
 
 If you wish to use this plugin alongside non Node functions like Python or functions with images, this plugin will automatically ignore any function which does not contain a handler or use a supported Node.js runtime.
 

--- a/e2e/__snapshots__/complete.test.ts.snap
+++ b/e2e/__snapshots__/complete.test.ts.snap
@@ -171,6 +171,7 @@ exports[`complete 5`] = `
                 "Action": [
                   "logs:CreateLogStream",
                   "logs:CreateLogGroup",
+                  "logs:TagResource",
                 ],
                 "Effect": "Allow",
                 "Resource": [

--- a/e2e/__snapshots__/individually.test.ts.snap
+++ b/e2e/__snapshots__/individually.test.ts.snap
@@ -390,6 +390,7 @@ exports[`individually 6`] = `
                 "Action": [
                   "logs:CreateLogStream",
                   "logs:CreateLogGroup",
+                  "logs:TagResource",
                 ],
                 "Effect": "Allow",
                 "Resource": [

--- a/e2e/__snapshots__/minimal.test.ts.snap
+++ b/e2e/__snapshots__/minimal.test.ts.snap
@@ -14087,6 +14087,7 @@ exports[`minimal 5`] = `
                 "Action": [
                   "logs:CreateLogStream",
                   "logs:CreateLogGroup",
+                  "logs:TagResource",
                 ],
                 "Effect": "Allow",
                 "Resource": [

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -217,27 +217,42 @@ export type AwsNodeProviderRuntimeMatcher<Versions extends number> = {
   [Version in Versions as `nodejs${Version}.x`]: `node${Version}`;
 };
 
+export type AzureNodeProviderRuntimeMatcher<Versions extends number> = {
+  [Version in Versions as `nodejs${Version}`]: `node${Version}`;
+};
+
 export type GoogleNodeProviderRuntimeMatcher<Versions extends number> = {
   [Version in Versions as `nodejs${Version}`]: `node${Version}`;
 };
 
 export type AwsNodeMatcher = AwsNodeProviderRuntimeMatcher<12 | 14 | 16 | 18>;
 
+export type AzureNodeMatcher = AzureNodeProviderRuntimeMatcher<12 | 14 | 16 | 18>;
+
 export type GoogleNodeMatcher = GoogleNodeProviderRuntimeMatcher<12 | 14 | 16 | 18>;
 
-export type NodeMatcher = AwsNodeMatcher & GoogleNodeMatcher;
+export type NodeMatcher = AwsNodeMatcher & AzureNodeMatcher & GoogleNodeMatcher;
 
 export type AwsNodeMatcherKey = keyof AwsNodeMatcher;
 
+export type AzureNodeMatcherKey = keyof AzureNodeMatcher;
+
 export type GoogleNodeMatcherKey = keyof GoogleNodeMatcher;
 
-export type NodeMatcherKey = AwsNodeMatcherKey | GoogleNodeMatcherKey;
+export type NodeMatcherKey = AwsNodeMatcherKey | AzureNodeMatcherKey | GoogleNodeMatcherKey;
 
 const awsNodeMatcher: AwsNodeMatcher = {
   'nodejs18.x': 'node18',
   'nodejs16.x': 'node16',
   'nodejs14.x': 'node14',
   'nodejs12.x': 'node12',
+};
+
+const azureNodeMatcher: AzureNodeMatcher = {
+  nodejs18: 'node18',
+  nodejs16: 'node16',
+  nodejs14: 'node14',
+  nodejs12: 'node12',
 };
 
 const googleNodeMatcher: GoogleNodeMatcher = {
@@ -247,10 +262,11 @@ const googleNodeMatcher: GoogleNodeMatcher = {
   nodejs12: 'node12',
 };
 
-const nodeMatcher: NodeMatcher = { ...googleNodeMatcher, ...awsNodeMatcher };
+const nodeMatcher: NodeMatcher = { ...googleNodeMatcher, ...awsNodeMatcher, ...azureNodeMatcher };
 
 export const providerRuntimeMatcher = Object.freeze<Record<string, NodeMatcher>>({
   aws: awsNodeMatcher as NodeMatcher,
+  azure: azureNodeMatcher as NodeMatcher,
   google: googleNodeMatcher as NodeMatcher,
 });
 


### PR DESCRIPTION
Adds support for Azure Function Apps built in Node via the `serverless-azure-functions` plugin.

Currently when trying to use the plugin with the `azure` runtime it does not compile because there is not a function matcher available, only for AWS and GCP.

This commit adds a matcher for Azure, along with unit tests and supporting documentation in README.md.

## Context
I originally had #445 opened, but upon further investigation the `esbuild` binary was never being invoked because the plugin ignored all `azure` runtime functions. I have since created a matcher and can confirm that the `esbuild` plugins functionality is working correctly.

This PR is raised to increase the compatibility of the plugin with other serverless runtimes, but it might be pertinent to add a warning whenever a function is being skipped e.g. an unsupported runtime or cloud.

Temporarily published to https://www.npmjs.com/package/@danielwaghorn/serverless-esbuild for testing if you wish to install locally.