### PR TITLE
fix: lint warnings

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
-import { build, BuildResult } from 'esbuild';
-import type { BuildOptions } from 'esbuild';
+import { build } from 'esbuild';
+import type { BuildOptions, BuildResult } from 'esbuild';
 import fs from 'fs-extra';
 import pMap from 'p-map';
 import path from 'path';

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -47,9 +47,7 @@ export function extractFunctionEntries(
 
       // Check that the file indeed exists.
       if (!fs.existsSync(path.join(cwd, entry))) {
-        console.log(`Cannot locate entrypoint, ${entry} not found`);
-
-        throw new Error('Compilation failed');
+        throw new Error(`Compilation failed. Cannot locate entrypoint, ${entry} not found`);
       }
 
       return [{ entry, func: null }];
@@ -92,8 +90,6 @@ export function extractFunctionEntries(
     }
 
     // Can't find the files. Watch will have an exception anyway. So throw one with error.
-    console.log(`Cannot locate handler - ${fileName} not found`);
-
     throw new Error(
       'Compilation failed. Please ensure you have an index file with ext .ts or .js, or have a path listed as main key in package.json'
     );

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -8,8 +8,6 @@ import type { Configuration, DependencyMap } from '../types';
 
 jest.mock('fs-extra');
 
-const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
-
 afterAll(() => {
   jest.resetAllMocks();
 });
@@ -173,7 +171,6 @@ describe('extractFunctionEntries', () => {
       };
 
       expect(() => extractFunctionEntries(cwd, 'aws', functionDefinitions)).toThrowError();
-      expect(consoleSpy).toBeCalled();
     });
   });
 
@@ -333,7 +330,6 @@ describe('extractFunctionEntries', () => {
       };
 
       expect(() => extractFunctionEntries(cwd, 'azure', functionDefinitions)).toThrowError();
-      expect(consoleSpy).toBeCalled();
     });
   });
 });


### PR DESCRIPTION
There were three warnings from eslint, two about console.log and one about BuildResult only used as a type. 