### PR TITLE
Update README.md: Set target to 'node16'

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The following `esbuild` options are automatically set.
 | `incremental` | N/A        | Cannot be overridden. Use `disableIncremental` to disable it           |
 | `outDir`      | N/A        | Cannot be overridden                                                   |
 | `platform`    | `'node'`   | Set `format` to `esm` to enable ESM support                            |
-| `target`      | `'node12'` | We dynamically set this. See [Supported Runtimes](#supported-runtimes) |
+| `target`      | `'node16'` | We dynamically set this. See [Supported Runtimes](#supported-runtimes) |
 | `watch`       | N/A        | Cannot be overridden                                                   |
 
 #### Packager Options


### PR DESCRIPTION
Hi folks,

Minor change to docs to set `target: 'node16'` instead of outdated node12.

Please let me know if this makes sense.
Thanks