### PR TITLE
feat: improves error message when handler is not found

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -91,7 +91,7 @@ export function extractFunctionEntries(
 
     // Can't find the files. Watch will have an exception anyway. So throw one with error.
     throw new Error(
-      'Compilation failed. Please ensure you have an index file with ext .ts or .js, or have a path listed as main key in package.json'
+      `Compilation failed for function alias ${functionAlias}. Please ensure you have an index file with ext .ts or .js, or have a path listed as main key in package.json`
     );
   });
 }


### PR DESCRIPTION
When moving from a different bundler to serverless-esbuild it can be hard to find mistakes with the generic error message provided in the `extractFunctionEntries` method.
To give developers at least a hint where the issue can be found this change adds the function alias to the error message.