### PR TITLE
Notify serverless-offline when watched files trigger rebuild

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -360,6 +360,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     chokidar.watch(allPatterns, options).on('all', (eventName, srcPath) =>
       this.bundle(true)
         .then(() => this.updateFile(eventName, srcPath))
+        .then(() => this.notifyServerlessOffline())
         .then(() => this.log.verbose('Watching files for changes...'))
         .catch(() => this.log.error('Bundle error, waiting for a file change to reload...'))
     );
@@ -398,6 +399,10 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
         ...(patterns.length && { patterns }),
       };
     }
+  }
+
+  notifyServerlessOffline() {
+    this.serverless.pluginManager.spawn('offline:functionsUpdated');
   }
 
   async updateFile(op: string, filename: string) {


### PR DESCRIPTION
This is my first time contributing. Please let me know what you'd like to see in terms of tests, documentation, etc - thanks!

## Background
- With a default `serverless-offline` + `serverless-esbuild` setup, watching for changes does not work
- See https://github.com/floydspace/serverless-esbuild/issues/108

## Problem
- The `--reloadHandler` solution proposed in the above issue drastically hurts local dev performance on a large project

## Proposal
- Leverage https://github.com/dherault/serverless-offline/pull/1093 to tell `serverless-offline` when it needs to clear the cache

## Alternatives
- If https://github.com/floydspace/serverless-esbuild/issues/158 was built, this may not be necessary
- For example with `serverless-webpack`, which already supports lifecycle hooks, I use a custom plugin to solve this exact same problem:
```js
class OfflineInvalidate {
  constructor(serverless) {
    this.hooks = {
      'after:webpack:compile:watch:compile': () =>
        serverless.pluginManager.spawn('offline:functionsUpdated'),
    };
  }
}
module.exports = OfflineInvalidate;
```
- I'd still prefer this proposed PR, so that watching "just works" with a default setup