### PR TITLE
Fix spawning too many esbuilds builds

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import type { BuildOptions } from 'esbuild';
+import type { BuildOptions, BuildResult } from 'esbuild';
 import fs from 'fs-extra';
 import pMap from 'p-map';
 import path from 'path';
@@ -102,7 +102,12 @@ export async function bundle(this: EsbuildServerlessPlugin): Promise<void> {
 
     const pkg = await import('esbuild');
     const context: BuildContext = await pkg.context(options);
-    const result = await context.rebuild();
+    let result!: BuildResult;
+    if (context) {
+      result = await context.rebuild();
+    } else {
+      result = await pkg.build(options);
+    }
 
     if (config.metafile) {
       fs.writeFileSync(

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import { build } from 'esbuild';
 import type { BuildOptions } from 'esbuild';
 import fs from 'fs-extra';
 import pMap from 'p-map';
@@ -101,8 +100,9 @@ export async function bundle(this: EsbuildServerlessPlugin): Promise<void> {
       outdir: path.join(buildDirPath, path.dirname(entry)),
     };
 
-    let context!: BuildContext;
-    const result = await build(options);
+    const pkg = await import('esbuild');
+    const context: BuildContext = await pkg.context(options);
+    const result = await context.rebuild();
 
     if (config.metafile) {
       fs.writeFileSync(

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       },
       'after:package:createDeploymentArtifacts': async () => {
         this.log.verbose('after:package:createDeploymentArtifacts');
-        await this.disposeContexes();
+        await this.disposeContexts();
         await this.cleanup();
       },
       'before:deploy:function:packageFunction': async () => {
@@ -171,7 +171,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       },
       'after:deploy:function:packageFunction': async () => {
         this.log.verbose('after:deploy:function:packageFunction');
-        await this.disposeContexes();
+        await this.disposeContexts();
         await this.cleanup();
       },
       'before:invoke:local:invoke': async () => {
@@ -182,7 +182,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
         await this.preLocal();
       },
       'after:invoke:local:invoke': async () => {
-        await this.disposeContexes();
+        await this.disposeContexts();
       },
     };
   }
@@ -515,7 +515,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     service.package.artifact = path.join(SERVERLESS_FOLDER, path.basename(service.package.artifact));
   }
 
-  async disposeContexes(): Promise<void> {
+  async disposeContexts(): Promise<void> {
     for (const { context } of Object.values(this.buildCache)) {
       if (context) {
         await context.dispose();

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       },
       'after:package:createDeploymentArtifacts': async () => {
         this.log.verbose('after:package:createDeploymentArtifacts');
+        await this.disposeContexes();
         await this.cleanup();
       },
       'before:deploy:function:packageFunction': async () => {
@@ -170,6 +171,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       },
       'after:deploy:function:packageFunction': async () => {
         this.log.verbose('after:deploy:function:packageFunction');
+        await this.disposeContexes();
         await this.cleanup();
       },
       'before:invoke:local:invoke': async () => {
@@ -178,6 +180,9 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
         await this.packExternalModules();
         await this.copyExtras();
         await this.preLocal();
+      },
+      'after:invoke:local:invoke': async () => {
+        await this.disposeContexes();
       },
     };
   }
@@ -508,6 +513,14 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     }
 
     service.package.artifact = path.join(SERVERLESS_FOLDER, path.basename(service.package.artifact));
+  }
+
+  async disposeContexes(): Promise<void> {
+    for (const { context } of Object.values(this.buildCache)) {
+      if (context) {
+        await context.dispose();
+      }
+    }
   }
 
   async cleanup(): Promise<void> {


### PR DESCRIPTION
My initial upgrade to esbuild 0.19 causes an easily reproducible issue that made the plugin spawn too many esbuild builds that would cauase memory to spike. This can be seen if you set esbuild to watch for changes and then repeatedly save the same file over and over.

I caused these as I ran into an issue where running serverless invoke and serverless package would never finish when calling rebuild. Using build seemingly solved this, but it ended up causing the issue spawning too many builds described above.

The actual underlying issue was that the context of these rebuilds are needed to be disposed of when we are finished building.

I added a step on finishing invoking, deploying and packaging to make sure to dispose of the contexts. I did not dispose of them on long running process of serverless offline as the context may be needed to rebuild when watching.