### PR TITLE
fix: custom esbuild.config.js loader

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -292,6 +292,8 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
   }
 
   private getBuildOptions() {
+    if (this.buildOptions) return this.buildOptions;
+
     const DEFAULT_BUILD_OPTIONS: Partial<Configuration> = {
       concurrency: Infinity,
       zipConcurrency: Infinity,


### PR DESCRIPTION
Hey guys, 

I was trying to update serverless-esbuild to the latest version but I was having issues invoking local functions with `serverless invoke local -f <function>` and using the custom config esbuild file feature.

```yaml
custom:
   esbuild:
      config: esbuild.config.js
```

I was getting this error:

```
Error: Cannot find module '<project-path>/.esbuild/.build/esbuild.config.js'
```

And the thing is that only for the pre-local script monkey patching the serviceDir to the build project dir and for that change the `require` cannot find the esbuild.config.js

I made a simple change, cache the buildOptions.

By doing this we avoid to call the `getBuildOptions` twice and with the wrong configuration paths.