### PR TITLE
fix: recursively search for packer lock file for all 3 packers supported

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,9 +47,9 @@ const isPathRoot = (p: string) => rootOf(p) === path.resolve(p);
 const findUpIO = (names: string[], directory = process.cwd()): IOO.IOOption<string> =>
   pipe(path.resolve(directory), (dir) =>
     pipe(
-      IO.of(names.map((name) => safeFileExistsIO(path.join(dir, name))).some((value) => value())),
-      IO.chain((exists: boolean) => {
-        if (exists) return IOO.some(dir);
+      IO.sequenceArray(names.map((name) => safeFileExistsIO(path.join(dir, name)))),
+      IO.chain((exist) => {
+        if (exist.some(Boolean)) return IOO.some(dir);
         if (isPathRoot(dir)) return IOO.none;
         return findUpIO(names, path.dirname(dir));
       })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,10 +44,10 @@ export function spawnProcess(command: string, args: string[], options: execa.Opt
 
 const rootOf = (p: string) => path.parse(path.resolve(p)).root;
 const isPathRoot = (p: string) => rootOf(p) === path.resolve(p);
-const findUpIO = (name: string, directory = process.cwd()): IOO.IOOption<string> =>
+const findUpIO = (names: string[], directory = process.cwd()): IOO.IOOption<string> =>
   pipe(path.resolve(directory), (dir) =>
     pipe(
-      safeFileExistsIO(path.join(dir, name)),
+      array.some(names.map((name) => safeFileExistsIO(path.join(dir, name)))),
       IO.chain((exists: boolean) => {
         if (exists) return IOO.some(dir);
         if (isPathRoot(dir)) return IOO.none;
@@ -67,9 +67,7 @@ export const findUp = (name: string) => pipe(findUpIO(name), IOO.toUndefined)();
 export const findProjectRoot = (rootDir?: string) =>
   pipe(
     IOO.fromNullable(rootDir),
-    IOO.fold(() => findUpIO('yarn.lock'), IOO.of),
-    IOO.fold(() => findUpIO('pnpm-lock.yaml'), IOO.of),
-    IOO.fold(() => findUpIO('package-lock.json'), IOO.of),
+    IOO.fold(() => findUpIO(['yarn.lock', 'pnpm-lock.yaml', 'package-lock.json']), IOO.of),
     IOO.toUndefined
   )();
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,11 +47,11 @@ const isPathRoot = (p: string) => rootOf(p) === path.resolve(p);
 const findUpIO = (names: string[], directory = process.cwd()): IOO.IOOption<string> =>
   pipe(path.resolve(directory), (dir) =>
     pipe(
-      array.some(names.map((name) => safeFileExistsIO(path.join(dir, name)))),
+      IO.of(names.map((name) => safeFileExistsIO(path.join(dir, name))).some((value) => value())),
       IO.chain((exists: boolean) => {
         if (exists) return IOO.some(dir);
         if (isPathRoot(dir)) return IOO.none;
-        return findUpIO(name, path.dirname(dir));
+        return findUpIO(names, path.dirname(dir));
       })
     )
   );
@@ -59,7 +59,7 @@ const findUpIO = (names: string[], directory = process.cwd()): IOO.IOOption<stri
 /**
  * Find a file by walking up parent directories
  */
-export const findUp = (name: string) => pipe(findUpIO(name), IOO.toUndefined)();
+export const findUp = (name: string) => pipe(findUpIO([name]), IOO.toUndefined)();
 
 /**
  * Forwards `rootDir` or finds project root folder.


### PR DESCRIPTION
This is a quick fix for issue #485.

I stumbled upon it by accident but basically I had a yarn.lock file in my home folder, and because the mechanism for recursively finding the lock file of the project runs up the directory chain outside of the scope of the repo, it could happen.

In the issue i described 2 possible solutions i could see, and decided to push this parallel search as an easy way to fix it. It should basically look recursively up the folder tree for either a package-lock, yarn-lock or pnpm-lock file and stop when it finds one of them rather than first looking for a yarn.lock up into infinity and if it can't find one, move on to the next possible packer lock file and so forth...
