### PR TITLE
feat: add support for resolve extensions esbuild setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ See [example folder](examples) for some example configurations.
 | `watch`                | Watch options for `serverless-offline`.                                                                                                                                                            | [Watch Options](#watch-options)                     |
 | `skipBuild`            | Avoid rebuilding lambda artifacts in favor of reusing previous build artifacts.                                                                                                                    | `false`                                             |
 | `skipBuildExcludeFns` | An array of lambda names that will always be rebuilt if `skipBuild` is set to `true` and bundling individually. This is helpful for dynamically generated functions like serverless-plugin-warmup. | `[]`                                                 |
+| `stripEntryResolveExtensions` | A boolean that determines if entrypoints using custom file extensions provided in the `resolveExtensions` ESbuild setting should be stripped of their custom extension upon packing the final bundle for that file. Example: `myLambda.custom.ts` would result in `myLambda.js` instead of `myLambda.custom.js`.
 
 #### Default Esbuild Options
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -39,6 +39,7 @@ export async function bundle(this: EsbuildServerlessPlugin): Promise<void> {
     'nodeExternals',
     'skipBuild',
     'skipBuildExcludeFns',
+    'stripEntryResolveExtensions',
   ].reduce<Record<string, any>>((options, optionName) => {
     const { [optionName]: _, ...rest } = options;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,4 @@ export const SERVERLESS_FOLDER = '.serverless';
 export const BUILD_FOLDER = '.build';
 export const WORK_FOLDER = '.esbuild';
 export const ONLY_PREFIX = '__only_';
+export const DEFAULT_EXTENSIONS = ['.ts', '.js', '.jsx', '.tsx'];

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -11,6 +11,7 @@ import type Serverless from 'serverless';
 import type ServerlessPlugin from 'serverless/classes/Plugin';
 import type { Configuration, DependencyMap, FunctionEntry } from './types';
 import type { EsbuildFunctionDefinitionHandler } from './types';
+import { DEFAULT_EXTENSIONS } from './constants';
 
 export function asArray<T>(data: T | T[]): T[] {
   return Array.isArray(data) ? data : [data];
@@ -27,7 +28,8 @@ export function assertIsString(input: unknown, message = 'input is not a string'
 export function extractFunctionEntries(
   cwd: string,
   provider: string,
-  functions: Record<string, Serverless.FunctionDefinitionHandler>
+  functions: Record<string, Serverless.FunctionDefinitionHandler>,
+  resolveExtensions?: string[]
 ): FunctionEntry[] {
   // The Google provider will use the entrypoint not from the definition of the
   // handler function, but instead from the package.json:main field, or via a
@@ -69,7 +71,7 @@ export function extractFunctionEntries(
       // replace only last instance to allow the same name for file and handler
       const fileName = handler.substring(0, fnNameLastAppearanceIndex);
 
-      const extensions = ['.ts', '.js', '.jsx', '.tsx'];
+      const extensions = resolveExtensions ?? DEFAULT_EXTENSIONS;
 
       for (const extension of extensions) {
         // Check if the .{extension} files exists. If so return that to watch

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -316,7 +316,7 @@ export const buildServerlessV3LoggerFromLegacyLogger = (
   success: legacyLogger.log.bind(legacyLogger),
 });
 
-export const stripResolveExtensions = (file: IFile, extensions: string[]): IFile => {
+export const stripEntryResolveExtensions = (file: IFile, extensions: string[]): IFile => {
   const resolveExtensionMatch = file.localPath.match(extensions.map((ext) => ext).join('|'));
 
   if (resolveExtensionMatch?.length && !DEFAULT_EXTENSIONS.includes(resolveExtensionMatch[0])) {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -9,7 +9,7 @@ import { uniq } from 'ramda';
 
 import type Serverless from 'serverless';
 import type ServerlessPlugin from 'serverless/classes/Plugin';
-import type { Configuration, DependencyMap, FunctionEntry } from './types';
+import type { Configuration, DependencyMap, FunctionEntry, IFile } from './types';
 import type { EsbuildFunctionDefinitionHandler } from './types';
 import { DEFAULT_EXTENSIONS } from './constants';
 
@@ -315,3 +315,18 @@ export const buildServerlessV3LoggerFromLegacyLogger = (
   verbose: legacyLogger.log.bind(legacyLogger),
   success: legacyLogger.log.bind(legacyLogger),
 });
+
+export const stripResolveExtensions = (file: IFile, extensions: string[]): IFile => {
+  const resolveExtensionMatch = file.localPath.match(extensions.map((ext) => ext).join('|'));
+
+  if (resolveExtensionMatch?.length && !DEFAULT_EXTENSIONS.includes(resolveExtensionMatch[0])) {
+    const extensionParts = resolveExtensionMatch[0].split('.');
+
+    return {
+      ...file,
+      localPath: file.localPath.replace(resolveExtensionMatch[0], `.${extensionParts[extensionParts.length - 1]}`),
+    };
+  }
+
+  return file;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,6 +320,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       outputFileExtension: '.js',
       skipBuild: false,
       skipBuildExcludeFns: [],
+      stripEntryResolveExtensions: false,
     };
 
     const providerRuntime = this.serverless.service.provider.runtime;

--- a/src/index.ts
+++ b/src/index.ts
@@ -345,7 +345,12 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
   }
 
   get functionEntries() {
-    return extractFunctionEntries(this.serviceDirPath, this.serverless.service.provider.name, this.functions);
+    return extractFunctionEntries(
+      this.serviceDirPath,
+      this.serverless.service.provider.name,
+      this.functions,
+      this.buildOptions?.resolveExtensions
+    );
   }
 
   watch(): void {

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -9,7 +9,7 @@ import semver from 'semver';
 import type Serverless from 'serverless';
 
 import { ONLY_PREFIX, SERVERLESS_FOLDER } from './constants';
-import { assertIsString, doSharePath, flatDep, getDepsFromBundle, isESM, stripResolveExtensions } from './helper';
+import { assertIsString, doSharePath, flatDep, getDepsFromBundle, isESM, stripEntryResolveExtensions } from './helper';
 import { getPackager } from './packagers';
 import { humanSize, trimExtension, zip } from './utils';
 
@@ -117,8 +117,8 @@ export async function pack(this: EsbuildServerlessPlugin) {
     .map((localPath) => ({ localPath, rootPath: path.join(buildDirPath, localPath) }))
     .map((file) => {
       if (this.buildOptions?.resolveExtensions && this.buildOptions.resolveExtensions.length > 0) {
-        if (this.options.stripResolveExtensions) {
-          return stripResolveExtensions(file, this.buildOptions.resolveExtensions);
+        if (this.buildOptions.stripEntryResolveExtensions) {
+          return stripEntryResolveExtensions(file, this.buildOptions.resolveExtensions);
         }
       }
 

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -2,9 +2,9 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 
-import { extractFunctionEntries, flatDep, getDepsFromBundle, isESM } from '../helper';
+import { extractFunctionEntries, flatDep, getDepsFromBundle, isESM, stripResolveExtensions } from '../helper';
 
-import type { Configuration, DependencyMap } from '../types';
+import type { Configuration, DependencyMap, IFile } from '../types';
 
 jest.mock('fs-extra');
 
@@ -641,5 +641,17 @@ describe('flatDeps', () => {
 
       expect(result).toStrictEqual(expectedResult);
     });
+  });
+});
+
+describe('stripResolveExtensions', () => {
+  it('should remove custom extension prefixes', () => {
+    const result = stripResolveExtensions({ localPath: 'test.custom.js' } as IFile, ['.custom.js']);
+    expect(result.localPath).toEqual('test.js');
+  });
+
+  it('should ignore prefixes not inside the resolve extensions list', () => {
+    const result = stripResolveExtensions({ localPath: 'test.other.js' } as IFile, ['.custom.js']);
+    expect(result.localPath).toEqual('test.other.js');
   });
 });

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -135,6 +135,35 @@ describe('extractFunctionEntries', () => {
       ]);
     });
 
+    it('should allow resolve extensions custom Esbuild setting', () => {
+      jest.mocked(fs.existsSync).mockReturnValue(true);
+      const functionDefinitions = {
+        function1: {
+          events: [],
+          handler: './file1.handler',
+        },
+        function2: {
+          events: [],
+          handler: './file2.handler',
+        },
+      };
+
+      const fileNames = extractFunctionEntries(cwd, 'aws', functionDefinitions, ['.custom.ts']);
+
+      expect(fileNames).toStrictEqual([
+        {
+          entry: 'file1.custom.ts',
+          func: functionDefinitions.function1,
+          functionAlias: 'function1',
+        },
+        {
+          entry: 'file2.custom.ts',
+          func: functionDefinitions.function2,
+          functionAlias: 'function2',
+        },
+      ]);
+    });
+
     it('should not return entries for handlers which have skipEsbuild set to true', async () => {
       jest.mocked(fs.existsSync).mockReturnValue(true);
       const functionDefinitions = {

--- a/src/tests/helper.test.ts
+++ b/src/tests/helper.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 
-import { extractFunctionEntries, flatDep, getDepsFromBundle, isESM, stripResolveExtensions } from '../helper';
+import { extractFunctionEntries, flatDep, getDepsFromBundle, isESM, stripEntryResolveExtensions } from '../helper';
 
 import type { Configuration, DependencyMap, IFile } from '../types';
 
@@ -644,14 +644,14 @@ describe('flatDeps', () => {
   });
 });
 
-describe('stripResolveExtensions', () => {
+describe('stripEntryResolveExtensions', () => {
   it('should remove custom extension prefixes', () => {
-    const result = stripResolveExtensions({ localPath: 'test.custom.js' } as IFile, ['.custom.js']);
+    const result = stripEntryResolveExtensions({ localPath: 'test.custom.js' } as IFile, ['.custom.js']);
     expect(result.localPath).toEqual('test.js');
   });
 
   it('should ignore prefixes not inside the resolve extensions list', () => {
-    const result = stripResolveExtensions({ localPath: 'test.other.js' } as IFile, ['.custom.js']);
+    const result = stripEntryResolveExtensions({ localPath: 'test.other.js' } as IFile, ['.custom.js']);
     expect(result.localPath).toEqual('test.other.js');
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,6 @@ export type ReturnPluginsFn = (sls: Serverless) => Plugins;
 
 export interface ImprovedServerlessOptions extends Serverless.Options {
   package?: string;
-  stripResolveExtensions?: boolean;
 }
 
 export interface WatchConfiguration {
@@ -48,6 +47,7 @@ export interface Configuration extends EsbuildOptions {
   nodeExternals?: NodeExternalsOptions;
   skipBuild?: boolean;
   skipBuildExcludeFns: string[];
+  stripEntryResolveExtensions?: boolean;
 }
 
 export interface EsbuildFunctionDefinitionHandler extends Serverless.FunctionDefinitionHandler {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type ReturnPluginsFn = (sls: Serverless) => Plugins;
 
 export interface ImprovedServerlessOptions extends Serverless.Options {
   package?: string;
+  stripResolveExtensions?: boolean;
 }
 
 export interface WatchConfiguration {


### PR DESCRIPTION
Support the ability to add custom resolution extensions via ESbuild settings. This is a feature of ESbuild and will allow for customization of lambda entrypoints. My team will be using this to support building different files based on the target environment we are deploying to.

Example:

`myLambda.dev.ts`
`myLambda.prod.ts`
`myLambda.ts`

When the environment we build for matches the extension of the file then that entrypoint will be used otherwise it will fallback to the default file resolutions in the order of our choosing. If the user of this plugin doesn't pass a `resolveExtensions` ESbuild setting then it will fallback to the array that was already defined by the repo.

https://esbuild.github.io/api/#resolve-extensions

## Notes:

When using custom extensions as the entrypoint for lambdas AWS can complain if the file uses a custom extension. To resolve this I have also added a `stripEntryResolveExtensions` option to the plugin which will remove custom extension prefixes if they are used in the resolveExtensions list. This will result in files that have extensions like `test.custom.js` to be renamed as `test.js` in the eventual packed file. I'm open to suggestions if there is a better way to handle this or if this behavior should be the default for any custom extensions assuming the approach in this PR is approved.