### PR TITLE
Update README.md to include aws runtime nodejs20.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ This plugin will automatically set the esbuild `target` for the following suppor
 
 | Runtime      | Target   |
 | ------------ | -------- |
+| `nodejs20.x` | `node20` |
 | `nodejs18.x` | `node18` |
 | `nodejs16.x` | `node16` |
 | `nodejs14.x` | `node14` |


### PR DESCRIPTION
This [code](https://github.com/floydspace/serverless-esbuild/blob/31dd88fe89d934a1178b3e50f1e390e5ccf2e4fb/src/helper.ts#L254) seams to support nodejs20.x but it is not included in the README.

I also noticed that [this plugins page on serverless.com](https://www.serverless.com/plugins/serverless-esbuild#supported-runtimes) is outdated but i don't know how to update that 