### PR TITLE
Implement 'disposeContext' option in Configuration and EsbuildFunctionDefinitionHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ See [example folder](examples) for some example configurations.
 | `skipBuild`            | Avoid rebuilding lambda artifacts in favor of reusing previous build artifacts.                                                                                                                    | `false`                                             |
 | `skipBuildExcludeFns` | An array of lambda names that will always be rebuilt if `skipBuild` is set to `true` and bundling individually. This is helpful for dynamically generated functions like serverless-plugin-warmup. | `[]`                                                 |
 | `stripEntryResolveExtensions` | A boolean that determines if entrypoints using custom file extensions provided in the `resolveExtensions` ESbuild setting should be stripped of their custom extension upon packing the final bundle for that file. Example: `myLambda.custom.ts` would result in `myLambda.js` instead of `myLambda.custom.js`.
-
+| `disposeContext` | An option to disable the disposal of the context.(Functions can override the global `disposeContext` configuration by specifying their own `disposeContext` option in their individual configurations.) | `true`
 #### Default Esbuild Options
 
 The following `esbuild` options are automatically set.

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -40,6 +40,7 @@ export async function bundle(this: EsbuildServerlessPlugin): Promise<void> {
     'skipBuild',
     'skipBuildExcludeFns',
     'stripEntryResolveExtensions',
+    'disposeContext',
   ].reduce<Record<string, any>>((options, optionName) => {
     const { [optionName]: _, ...rest } = options;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     for (const [functionAlias, fn] of Object.entries(functions)) {
       const currFn = fn as EsbuildFunctionDefinitionHandler;
       if (this.isFunctionDefinitionHandler(currFn) && this.isNodeFunction(currFn)) {
-        buildOptions.disposeContext = currFn.disposeContext; // disposeContext configuration can be overridden per function
+        buildOptions.disposeContext = currFn.disposeContext ? currFn.disposeContext : buildOptions.disposeContext; // disposeContext configuration can be overridden per function
         if (buildOptions.skipBuild && !buildOptions.skipBuildExcludeFns?.includes(functionAlias)) {
           currFn.skipEsbuild = true;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     for (const [functionAlias, fn] of Object.entries(functions)) {
       const currFn = fn as EsbuildFunctionDefinitionHandler;
       if (this.isFunctionDefinitionHandler(currFn) && this.isNodeFunction(currFn)) {
+        buildOptions.disposeContext = currFn.disposeContext; // disposeContext configuration can be overridden per function
         if (buildOptions.skipBuild && !buildOptions.skipBuildExcludeFns?.includes(functionAlias)) {
           currFn.skipEsbuild = true;
         }
@@ -321,6 +322,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       skipBuild: false,
       skipBuildExcludeFns: [],
       stripEntryResolveExtensions: false,
+      disposeContext: true, // default true
     };
 
     const providerRuntime = this.serverless.service.provider.runtime;
@@ -526,7 +528,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
   async disposeContexts(): Promise<void> {
     for (const { context } of Object.values(this.buildCache)) {
       if (context) {
-        await context.dispose();
+        this.buildOptions?.disposeContext && (await context.dispose());
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,9 +48,11 @@ export interface Configuration extends EsbuildOptions {
   skipBuild?: boolean;
   skipBuildExcludeFns: string[];
   stripEntryResolveExtensions?: boolean;
+  disposeContext?: boolean;
 }
 
 export interface EsbuildFunctionDefinitionHandler extends Serverless.FunctionDefinitionHandler {
+  disposeContext?: boolean;
   skipEsbuild: boolean;
 }
 


### PR DESCRIPTION
**Description:**

This pull request addresses the issue explained in [#514](https://github.com/floydspace/serverless-esbuild/issues/514). We identified a challenge regarding the handling of context disposal in the serverless-esbuild plugin, which caused error and changed behavior of Lambda functions on every 3rd local invoke.

**Changes Made:**

**New _'disposeContext'_ Property:** I introduced a new property named **disposeContext** which has a default value as **'true'** in both **Configuration** and **EsbuildFunctionDefinitionHandler** interfaces. This property allows users to control whether the _disposeContexts()_ function should dispose of the context.

**Configuration Flexibility:** The **disposeContext** option can be set globally within the esbuild configuration in the serverless configuration file. This global setting applies to all Lambda functions utilizing the specific configuration.
Function-Level Override: Individual functions can override the global setting by including the **disposeContext** property in their own configurations.

**Backward Compatibility:** Careful consideration has been given to ensure backward compatibility with these changes. For existing users of the **serverless-esbuild** library who have not specified the **disposeContext** option in their configurations, there will be no disruption in functionality. This is because the **disposeContext** property is set to a default value of **'true'**. Consequently, the context disposal behavior will continue to operate as it did previously, maintaining the expected behavior for current users. This approach ensures a seamless transition for users updating to the version of the library that includes these new changes.

**Testing:** The testing for these changes was conducted within our own development environment, specifically tailored to our use case of programmatically invoking Lambda functions locally.

**Impact of Changes:**

This enhancement provides greater control over context management in Lambda functions, potentially improving performance and resource management for users of the serverless-esbuild plugin. It offers both a global and a function-specific configuration approach, catering to diverse use cases and deployment strategies.

I believe this feature can solve the problem of the ones who were facing with the same error and am looking forward to feedback from the maintainers and community.