### PR TITLE
feat: esm support

### DIFF
--- a/src/pack.ts
+++ b/src/pack.ts
@@ -38,7 +38,7 @@ function setFunctionArtifactPath(
   }
 }
 
-const excludedFilesDefault = ['package-lock.json', 'pnpm-lock.yaml', 'yarn.lock', 'package.json'];
+const excludedFilesDefault = ['package-lock.json', 'pnpm-lock.yaml', 'yarn.lock'];
 
 export const filterFilesForZipPackage = ({
   files,

--- a/src/packagers/npm.ts
+++ b/src/packagers/npm.ts
@@ -95,7 +95,7 @@ export class NPM implements Packager {
   }
 
   get copyPackageSectionNames() {
-    return [];
+    return ['type'];
   }
 
   get mustCopyModules() {

--- a/src/packagers/pnpm.ts
+++ b/src/packagers/pnpm.ts
@@ -14,7 +14,7 @@ export class Pnpm implements Packager {
   }
 
   get copyPackageSectionNames() {
-    return [];
+    return ['type'];
   }
 
   get mustCopyModules() {

--- a/src/packagers/yarn.ts
+++ b/src/packagers/yarn.ts
@@ -50,7 +50,7 @@ export class Yarn implements Packager {
   }
 
   get copyPackageSectionNames() {
-    return ['resolutions'];
+    return ['resolutions', 'type'];
   }
 
   get mustCopyModules() {


### PR DESCRIPTION
**Not ready to merge: working on tests**

This PR add the `type` keyword in the package.json and package every function with the `package.json` generated. 

Allows you to use esbuild with `format: 'esm'` without having to change the outputFileExtension to `mjs` that it doesn't work well with serverless sdk: https://github.com/serverless/serverless/issues/11308

Most of the time with this change + a banner to support `require` it's enough to have full support for esm.

esbuild.config.cjs
```js
...
format: 'esm',
banner: {
    js: 'import { createRequire as topLevelCreateRequire } from \'module\';\n const require = topLevelCreateRequire(import.meta.url);',
  },
...
```

related: https://github.com/floydspace/serverless-esbuild/issues/483