### PR TITLE
Add support for nodejs20 for Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ This plugin will automatically set the esbuild `target` for the following suppor
 | `nodejs14.x` | `node14` |
 | `nodejs12.x` | `node12` |
 
+### Google
+
+This plugin is compatible with the [serverless-google-cloudfunctions](https://github.com/serverless/serverless-google-cloudfunctions) plugin, and will set the runtimes accordingly.
+
+| Runtime      | Target   |
+| ------------ | -------- |
+| `nodejs20`   | `node20` |
+| `nodejs18`   | `node18` |
+| `nodejs16`   | `node16` |
+| `nodejs14`   | `node14` |
+| `nodejs12`   | `node12` |
+
 ### Azure
 
 This plugin is compatible with the [serverless-azure-functions](https://github.com/serverless/serverless-azure-functions) plugin, and will set the runtimes accordingly.

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -234,7 +234,7 @@ export type AwsNodeMatcher = AwsNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 2
 
 export type AzureNodeMatcher = AzureNodeProviderRuntimeMatcher<12 | 14 | 16 | 18>;
 
-export type GoogleNodeMatcher = GoogleNodeProviderRuntimeMatcher<12 | 14 | 16 | 18>;
+export type GoogleNodeMatcher = GoogleNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 20>;
 
 export type ScalewayNodeMatcher = ScalewayNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 20>;
 
@@ -266,6 +266,7 @@ const azureNodeMatcher: AzureNodeMatcher = {
 };
 
 const googleNodeMatcher: GoogleNodeMatcher = {
+  nodejs20: 'node20',
   nodejs18: 'node18',
   nodejs16: 'node16',
   nodejs14: 'node14',


### PR DESCRIPTION
This is a minor change to enable support for nodejs20 now that [Google Cloud Functions](https://cloud.google.com/functions/docs/concepts/nodejs-runtime) support it 