### PR TITLE
fix(bundle): remove rebuild because it causes slow performance on big…

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -107,12 +107,7 @@ export async function bundle(this: EsbuildServerlessPlugin): Promise<void> {
     type ContextFn = (opts: typeof options) => Promise<BuildContext>;
     type WithContext = typeof pkg & { context?: ContextFn };
     const context = await (pkg as WithContext).context?.(options);
-
-    let result = await context?.rebuild();
-
-    if (!result) {
-      result = await pkg.build(options);
-    }
+    const result = await pkg.build(options);
 
     if (config.metafile) {
       fs.writeFileSync(


### PR DESCRIPTION
When the project is large, rebuild causes memory problems and prevents deployment in github actions and other environments.