### PR TITLE
Fix: Added skipRebuild options to esbuildOptions

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -38,6 +38,7 @@ export async function bundle(this: EsbuildServerlessPlugin): Promise<void> {
     'outputWorkFolder',
     'nodeExternals',
     'skipBuild',
+    'skipRebuild',
     'skipBuildExcludeFns',
     'stripEntryResolveExtensions',
     'disposeContext',


### PR DESCRIPTION
Really simple fix to the latest skipRebuild options.

It was missing before and threw an error if I tried to include the option in my esbuild config. Works fine now after adding it here

