### PR TITLE
fix: preserve mtime when zipping

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,6 +1,9 @@
 name: pull
 
 on:
+  push:
+    branches:
+     - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -3,7 +3,7 @@ name: pull
 on:
   push:
     branches:
-     - master
+      - master
   pull_request:
     branches:
       - master
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: release
 on:
   push:
     branches:
-      - master
       - beta
       - alpha
 jobs:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,10 +115,12 @@ function nodeZip(zipPath: string, filesPathList: IFiles): Promise<void> {
       const stats = fs.statSync(file.rootPath);
       if (stats.isDirectory()) return;
 
+      stats.mtime = new Date(stats.mtime);
+
       zipArchive.append(fs.readFileSync(file.rootPath), {
         name: file.localPath,
         mode: stats.mode,
-        date: new Date(0), // necessary to get the same hash when zipping the same content
+        date: new Date(stats.mtime),
       });
     });
 


### PR DESCRIPTION
_this is a wip to run CI_

This means it's possible for code to retrieve the correct mtime, for example to return in a `Last-Modified` header.