### PR TITLE
fix: preserve mtime when zipping with the node zipper

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,7 +118,7 @@ function nodeZip(zipPath: string, filesPathList: IFiles): Promise<void> {
       zipArchive.append(fs.readFileSync(file.rootPath), {
         name: file.localPath,
         mode: stats.mode,
-        date: new Date(0), // necessary to get the same hash when zipping the same content
+        date: new Date(stats.mtime),
       });
     });
 


### PR DESCRIPTION
This means it's possible for code to retrieve the correct mtime, for example to return in a `Last-Modified` header. That's what I want to use this for: I'm bundling static assets in my Lambda and I want to be able to have clients cache them properly and send me `If-Modified-Since`.

Since we have a test which verifies a checksum of a zip file created by this function, we can be sure the results are deterministic. To support this, update the test inputs to have specified mtimes.

[Here's a test run on my fork][test]. You can see that I had to drop node 14 from CI, so if a run is approved it'll fail. This seems to be a pre-existing failure on master which [you can observe in other PRs][existing-failure].

[existing-failure]: https://github.com/floydspace/serverless-esbuild/actions/runs/9153001999/job/25249872740
[test]: https://github.com/iainlane/serverless-esbuild/actions/runs/9235648929