### PR TITLE
Fix memory leak when skipRebuild is true

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import type { BuildOptions } from 'esbuild';
+import * as pkg from 'esbuild';
 import fs from 'fs-extra';
 import pMap from 'p-map';
 import path from 'path';
@@ -103,11 +104,9 @@ export async function bundle(this: EsbuildServerlessPlugin): Promise<void> {
       outdir: path.join(buildDirPath, path.dirname(entry)),
     };
 
-    const pkg = await import('esbuild');
-
     type ContextFn = (opts: typeof options) => Promise<BuildContext>;
     type WithContext = typeof pkg & { context?: ContextFn };
-    const context = await (pkg as WithContext).context?.(options);
+    const context = buildOptions.skipRebuild ? undefined : await (pkg as WithContext).context?.(options);
 
     let result;
     if (!buildOptions.skipRebuild) {


### PR DESCRIPTION
This PR addresses https://github.com/floydspace/serverless-esbuild/issues/388

It is inspired by https://github.com/floydspace/serverless-esbuild/issues/388#issuecomment-1773183932

I run several different services locally in parallel with serverless-offline and serverless-esbuild. The largest one of those was chewing up 30+ GB of RAM just to build and run locally, and it didn't come down after the build was done.  We kept having to bump our GitHub Actions to larger runners in order to be able to run our integration tests chiefly because of this memory leak.

We have been using this fork for a month; The memory usage is far less and there are no apparent issues. By using the fork, we've cut our GitHub Action spend in half.