### PR TITLE
Fix: Don't filter out children of external dependencies

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -119,7 +119,7 @@ export const flatDep = (root: DependencyMap, rootDepsFilter: string[]): string[]
 
     Object.entries(deps).forEach(([depName, details]) => {
       // only for root level dependencies
-      if (filter && !filter.includes(depName)) {
+      if (details.isRootDep && filter && !filter.includes(depName)) {
         return;
       }
 


### PR DESCRIPTION
Fix: Don't filter out children of external dependencies.
isRootDep was not being checked during recursiveFind.

Related issue: https://github.com/floydspace/serverless-esbuild/issues/479