### PR TITLE
Revert "fix: preserve mtime when zipping with the node zipper (#539)"

### DIFF
--- a/src/tests/util.test.ts
+++ b/src/tests/util.test.ts
@@ -18,29 +18,15 @@ describe('utils/findProjectRoot', () => {
 });
 
 describe('utils/zip', () => {
-  const mtime = new Date(2024, 0, 1, 0, 0, 0, 0);
-
   beforeEach(() => {
     mockFs({
-      '/src': mockFs.directory({
-        mtime,
-        items: {
-          'test.txt': mockFs.file({
-            mtime,
-            content: 'lorem ipsum',
-          }),
-          modules: mockFs.directory({
-            mtime,
-            items: {
-              'module.txt': mockFs.file({
-                mtime,
-                content: 'lorem ipsum 2',
-              }),
-            },
-          }),
+      '/src': {
+        'test.txt': 'lorem ipsum',
+        modules: {
+          'module.txt': 'lorem ipsum 2',
         },
-      }),
-      '/dist': mockFs.directory({ mtime }),
+      },
+      '/dist': {},
     });
   });
 
@@ -79,17 +65,7 @@ describe('utils/zip', () => {
         },
       ];
 
-      // Check the mtimes are set correctly
-      const sourceStat = fs.statSync(source);
-      expect(sourceStat.mtime).toEqual(mtime);
-
-      const testStat = fs.statSync('/src/test.txt');
-      expect(testStat.mtime).toEqual(mtime);
-
-      const moduleStat = fs.statSync('/src/modules/module.txt');
-      expect(moduleStat.mtime).toEqual(mtime);
-
-      await expect(zip(zipPath, filesPathList, useNativeZip)).resolves.toBeUndefined();
+      await zip(zipPath, filesPathList, useNativeZip);
 
       expect(fs.existsSync(zipPath)).toEqual(true);
 
@@ -103,7 +79,7 @@ describe('utils/zip', () => {
       if (!useNativeZip) {
         const data = fs.readFileSync(zipPath);
         const fileHash = crypto.createHash('sha256').update(data).digest('base64');
-        expect(fileHash).toEqual('PHu2gv7OIMv+lAOCXYPNd30X8/7EKYTuV7KYJjw3Qd4=');
+        expect(fileHash).toEqual('iCZdyHJ7ON2LLwBIE6gQmRvBTzXBogSqJTMvHSenzGk=');
       }
     }
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,7 +112,7 @@ function nodeZip(zipPath: string, filesPathList: IFiles): Promise<void> {
       zipArchive.append(fs.readFileSync(file.rootPath), {
         name: file.localPath,
         mode: stats.mode,
-        date: new Date(stats.mtime),
+        date: new Date(0), // necessary to get the same hash when zipping the same content
       });
     });
 


### PR DESCRIPTION
This PR reverts commit 162d9bc7f0e87d63cd93adb0f4756d01769da79d, which introduced non-deterministic behavior in the bundling process, leading to unnecessary re-deployments even when no code changes occurred. This change addresses issue [#557](https://github.com/floydspace/serverless-esbuild/issues/557).

