### PR TITLE
feat: support ESM plugins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import type {
   ImprovedServerlessOptions,
   Plugins,
   ReturnPluginsFn,
+  ESMPluginsModule,
 } from './types';
 
 function updateFile(op: string, src: string, dest: string) {
@@ -254,7 +255,13 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       return this.buildOptions.plugins;
     }
 
-    const plugins: Plugins | ReturnPluginsFn = require(path.join(this.serviceDirPath, this.buildOptions.plugins));
+    let plugins: Plugins | ReturnPluginsFn | ESMPluginsModule = require(
+      path.join(this.serviceDirPath, this.buildOptions.plugins)
+    );
+
+    if (plugins.default) {
+      plugins = plugins.default;
+    }
 
     if (typeof plugins === 'function') {
       return plugins(this.serverless);

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type ConfigFn = (sls: Serverless) => Configuration;
 
 export type Plugins = Plugin[];
 export type ReturnPluginsFn = (sls: Serverless) => Plugins;
+export type ESMPluginsModule = { default: Plugins | ReturnPluginsFn };
 
 export interface ImprovedServerlessOptions extends Serverless.Options {
   package?: string;


### PR DESCRIPTION
This adds support for the `plugins` config file to be written in ESM format.

Example usage:

```js
// plugins.js

import MyPlugin from "my-esbuild-plugin";

export default [
  MyPlugin()
];
```