### PR TITLE
fix: enable compatibility for loading native ES modules with require()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -348,7 +348,12 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
 
     const configPath: string | undefined = this.serverless.service.custom?.esbuild?.config;
 
-    const config: ConfigFn | undefined = configPath ? require(path.join(this.serviceDirPath, configPath)) : undefined;
+    const config: ConfigFn | undefined = (() => {
+      if(!configPath) return undefined 
+      const modPath = path.join(this.serviceDirPath, configPath);
+      const mod = require(modPath);
+      return mod?.default ?? mod;
+    })();    
 
     return withResolvedOptions<Configuration>(
       config ? config(this.serverless) : this.serverless.service.custom?.esbuild ?? {}


### PR DESCRIPTION
Doing something similar to:
https://github.com/serverless/serverless/commit/8b960a2e92364149e463c274172dc9d08a37a836

I noticed an error when trying to use the function style config. e.g. `esbuild.config.mjs`. using node@20.19.0

Note that I did the change in node_modules and ported the code using github "edit".

Let me know if I have to do something special or make changes.

Its simple enough that you can apply something similar yourself and discard this.

Cheers.