### PR TITLE
feat: add node22 support for scaleway

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22.11.0]
+        node-version: [18, 20.18.3, 22.11.0]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22.11.0]
+        node-version: [18, 20.18.3, 22.11.0]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -237,7 +237,7 @@ export type AzureNodeMatcher = AzureNodeProviderRuntimeMatcher<12 | 14 | 16 | 18
 
 export type GoogleNodeMatcher = GoogleNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 20>;
 
-export type ScalewayNodeMatcher = ScalewayNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 20>;
+export type ScalewayNodeMatcher = ScalewayNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 20 | 22>;
 
 export type NodeMatcher = AwsNodeMatcher & AzureNodeMatcher & GoogleNodeMatcher & ScalewayNodeMatcher;
 
@@ -276,6 +276,7 @@ const googleNodeMatcher: GoogleNodeMatcher = {
 };
 
 const scalewayNodeMatcher: ScalewayNodeMatcher = {
+  node22: 'node22',
   node20: 'node20',
   node18: 'node18',
   node16: 'node16',


### PR DESCRIPTION
Add support for Node 22 on Scaleway

Scaleway's supported list of NodeJS runtimes is available [here](https://www.scaleway.com/en/docs/serverless-functions/reference-content/functions-runtimes/#nodejs).