### PR TITLE
docs: add Node.js 22 to AWS Lambda supported runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ This plugin will automatically set the esbuild `target` for the following suppor
 
 | Runtime      | Target   |
 | ------------ | -------- |
+| `nodejs22.x` | `node22` |
 | `nodejs20.x` | `node20` |
 | `nodejs18.x` | `node18` |
 | `nodejs16.x` | `node16` |


### PR DESCRIPTION
Thank you for maintaining this project!

This PR updates the README to include Node.js 22 in the list of supported AWS Lambda runtimes.

Node.js 22 support was added in [#560](https://github.com/floydspace/serverless-esbuild/pull/560), but the documentation was not updated accordingly. This change ensures that the README stays consistent with the actual runtime support.

Let me know if any additional changes are needed!

fix: https://github.com/floydspace/serverless-esbuild/issues/561