### PR TITLE
feat: add support for Node.js 22 and 24 for Google Cloud Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ This plugin is compatible with the [serverless-google-cloudfunctions](https://gi
 
 | Runtime      | Target   |
 | ------------ | -------- |
+| `nodejs24`   | `node24` |
+| `nodejs22`   | `node22` |
 | `nodejs20`   | `node20` |
 | `nodejs18`   | `node18` |
 | `nodejs16`   | `node16` |

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -235,7 +235,7 @@ export type AwsNodeMatcher = AwsNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 2
 
 export type AzureNodeMatcher = AzureNodeProviderRuntimeMatcher<12 | 14 | 16 | 18>;
 
-export type GoogleNodeMatcher = GoogleNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 20>;
+export type GoogleNodeMatcher = GoogleNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 20 | 22 | 24>;
 
 export type ScalewayNodeMatcher = ScalewayNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 20 | 22>;
 
@@ -268,6 +268,8 @@ const azureNodeMatcher: AzureNodeMatcher = {
 };
 
 const googleNodeMatcher: GoogleNodeMatcher = {
+  nodejs24: 'node24',
+  nodejs22: 'node22',
   nodejs20: 'node20',
   nodejs18: 'node18',
   nodejs16: 'node16',


### PR DESCRIPTION
## Description

Adds support for Node.js 22 and 24 runtimes for Google Cloud Functions now that [Google Cloud Functions](https://cloud.google.com/functions/docs/concepts/nodejs-runtime) support it.

## Changes

- Added `nodejs22` → `node22` and `nodejs24` → `node24` runtime mappings in `googleNodeMatcher`
- Updated `GoogleNodeMatcher` type to include versions 22 and 24
- Updated README documentation with the new supported runtimes
