### PR TITLE
fix: add Node.js v24 to AWS Lambda supported runtimes (#578)

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -231,7 +231,7 @@ export type ScalewayNodeProviderRuntimeMatcher<Versions extends number> = {
   [Version in Versions as `node${Version}`]: `node${Version}`;
 };
 
-export type AwsNodeMatcher = AwsNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 20 | 22>;
+export type AwsNodeMatcher = AwsNodeProviderRuntimeMatcher<12 | 14 | 16 | 18 | 20 | 22 | 24>;
 
 export type AzureNodeMatcher = AzureNodeProviderRuntimeMatcher<12 | 14 | 16 | 18>;
 
@@ -252,6 +252,7 @@ export type ScalewayNodeMatcherKey = keyof ScalewayNodeMatcher;
 export type NodeMatcherKey = AwsNodeMatcherKey | AzureNodeMatcherKey | GoogleNodeMatcherKey | ScalewayNodeMatcherKey;
 
 const awsNodeMatcher: AwsNodeMatcher = {
+  'nodejs24.x': 'node24',
   'nodejs22.x': 'node22',
   'nodejs20.x': 'node20',
   'nodejs18.x': 'node18',


### PR DESCRIPTION
Fixes #578 