### PR TITLE
npm: use "ci" (cleaninstall) if lockfiles are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ The following `esbuild` options are automatically set.
 
 #### Packager Options
 
-| Option           | Description                                                                                                                                                                        | Default     |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| `scripts`        | A string or array of scripts to be executed, currently only supports 'scripts' for npm, pnpm and yarn                                                                              | `undefined` |
-| `noInstall`      | [Yarn only] A boolean that deactivates the install step                                                                                                                            | `false`     |
-| `ignoreLockfile` | [Yarn only] A boolean to bypass lockfile validation, typically paired with `external` dependencies because we generate a new package.json with only the externalized dependencies. | `false`     |
+| Option           | Description                                                                                                                                                                             | Default     |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `scripts`        | A string or array of scripts to be executed, currently only supports 'scripts' for npm, pnpm and yarn                                                                                   | `undefined` |
+| `noInstall`      | [Yarn only] A boolean that deactivates the install step                                                                                                                                 | `false`     |
+| `ignoreLockfile` | [Yarn, npm only] A boolean to bypass lockfile validation, typically paired with `external` dependencies because we generate a new package.json with only the externalized dependencies. | `false`     |
 
 #### Watch Options
 

--- a/src/packagers/index.ts
+++ b/src/packagers/index.ts
@@ -14,10 +14,10 @@ import type { PackagerId, PackagerOptions } from '../types';
 import type { Packager } from './packager';
 
 const packagerFactories: Record<PackagerId, (packagerOptions: PackagerOptions) => Promise<Packager>> = {
-  async npm() {
+  async npm(packagerOptions: PackagerOptions) {
     const { NPM } = await import('./npm');
 
-    return new NPM();
+    return new NPM(packagerOptions);
   },
   async pnpm() {
     const { Pnpm } = await import('./pnpm');

--- a/src/packagers/npm.ts
+++ b/src/packagers/npm.ts
@@ -2,7 +2,7 @@ import { Predicate } from 'effect';
 import { any, isEmpty, replace, split, startsWith, takeWhile } from 'ramda';
 import * as path from 'path';
 
-import type { DependenciesResult, DependencyMap, JSONObject } from '../types';
+import type { DependenciesResult, DependencyMap, JSONObject, PackagerOptions } from '../types';
 import { SpawnError, spawnProcess } from '../utils';
 import type { Packager } from './packager';
 
@@ -90,6 +90,12 @@ export interface NpmV6Deps {
  * NPM packager.
  */
 export class NPM implements Packager {
+  private packagerOptions: PackagerOptions;
+
+  constructor(packagerOptions: PackagerOptions) {
+    this.packagerOptions = packagerOptions;
+  }
+
   get lockfileName() {
     return 'package-lock.json';
   }
@@ -269,10 +275,10 @@ export class NPM implements Packager {
     return lockfile;
   }
 
-  async install(cwd: string, extraArgs: Array<string>) {
+  async install(cwd: string, extraArgs: Array<string>, useLockfile: boolean) {
     const command = /^win/.test(process.platform) ? 'npm.cmd' : 'npm';
 
-    const args = ['install', ...extraArgs];
+    const args = [!this.packagerOptions.ignoreLockfile && useLockfile ? 'ci' : 'install', ...extraArgs];
 
     await spawnProcess(command, args, { cwd });
   }

--- a/src/tests/packagers/npm.test.ts
+++ b/src/tests/packagers/npm.test.ts
@@ -5,7 +5,7 @@ import * as utils from '../../utils';
 
 jest.mock('process');
 describe('NPM Packager', () => {
-  const npm = new NPM();
+  const npm = new NPM({});
   const path = './';
 
   let spawnSpy: jest.SpyInstance;


### PR DESCRIPTION
At work, we sometimes find that `sls package` fails because npm has resolved a
newer version than is available in our mirrors; as best as we can tell, this is
because the esbuild plugin is running `npm install` instead of `npm ci`. But we
want a fast, reproducible, known build, favoring the latter. This PR implements
that (see the commit message for details).

If there's a way to make this change non-breaking, I'm all ears. It seems
reasonable to want to toggle the behavior using the existing configuration.
