### PR TITLE
docs: add Node.js 24 to AWS Lambda supported runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ This plugin will automatically set the esbuild `target` for the following suppor
 
 | Runtime      | Target   |
 | ------------ | -------- |
+| `nodejs24.x` | `node24` |
 | `nodejs22.x` | `node22` |
 | `nodejs20.x` | `node20` |
 | `nodejs18.x` | `node18` |


### PR DESCRIPTION
Node.js 24 support was added in https://github.com/floydspace/serverless-esbuild/pull/579, but the documentation was not updated accordingly. This change ensures that the README stays consistent with the actual runtime support.