### PR TITLE
fix: remove zip staging directory recursively so it is not leaked

### DIFF
--- a/src/tests/util.test.ts
+++ b/src/tests/util.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import mockFs from 'mock-fs';
+import os from 'os';
 import path from 'path';
 import extract from 'extract-zip';
 import globby from 'globby';
@@ -81,6 +82,33 @@ describe('utils/zip', () => {
         const fileHash = crypto.createHash('sha256').update(data).digest('base64');
         expect(fileHash).toEqual('iCZdyHJ7ON2LLwBIE6gQmRvBTzXBogSqJTMvHSenzGk=');
       }
+    }
+  );
+
+  it.each([{ useNativeZip: true }, { useNativeZip: false }])(
+    'should remove its temporary staging directory when useNativeZip=$useNativeZip.',
+    async ({ useNativeZip }) => {
+      const source = '/src';
+      const destination = '/dist';
+      const zipPath = path.join(destination, 'archive.zip');
+      const filesPathList = [
+        {
+          rootPath: path.join(source, 'test.txt'),
+          localPath: 'test.txt',
+        },
+      ];
+
+      await zip(zipPath, filesPathList, useNativeZip);
+
+      // `zip` stages the archive contents in a directory under `os.tmpdir()` and releases
+      // it through `Effect.acquireRelease`. That release always removes a NON-EMPTY
+      // directory, so it has to recurse -- a non-recursive remove fails with ENOTEMPTY,
+      // the failure is swallowed by `Effect.orElse`, and one directory is left behind per
+      // archive on every packaging run.
+      const tmpDir = os.tmpdir();
+      const leaked = fs.existsSync(tmpDir) ? fs.readdirSync(tmpDir).filter((name) => name.startsWith('archive-')) : [];
+
+      expect(leaked).toEqual([]);
     }
   );
 });

--- a/src/utils/effect-fs.ts
+++ b/src/utils/effect-fs.ts
@@ -9,8 +9,17 @@ const FS = Effect.serviceFunctions(FileSystem.FileSystem);
 export const makePath = (p: string) => FS.makeDirectory(p, { recursive: true });
 export const safeFileExists = (p: string) => FS.exists(p).pipe(Effect.orElseSucceed(() => false));
 export const safeFileRemove = (p: string) => FS.remove(p).pipe(Effect.orElse(() => Effect.void));
+/**
+ * `safeFileRemove` for a directory that is expected to have contents.
+ *
+ * `FS.remove` is non-recursive by default, so pointing it at a populated directory fails
+ * with ENOTEMPTY. Callers here pipe through `Effect.orElse`, which swallows that failure --
+ * so a missing `recursive` does not surface as an error, it just silently leaves the
+ * directory on disk.
+ */
+export const safeDirRemove = (p: string) => FS.remove(p, { recursive: true }).pipe(Effect.orElse(() => Effect.void));
 export const makeTempPathScoped = (dirName: string) =>
-  Effect.acquireRelease(Effect.succeed(path.join(os.tmpdir(), dirName)).pipe(Effect.tap(makePath)), safeFileRemove);
+  Effect.acquireRelease(Effect.succeed(path.join(os.tmpdir(), dirName)).pipe(Effect.tap(makePath)), safeDirRemove);
 
 export const FSyncLayer = FileSystem.layerNoop({
   exists: (p) =>


### PR DESCRIPTION
## The bug

`zip()` stages each archive in a directory under `os.tmpdir()` and releases it with `Effect.acquireRelease`. The release is `safeFileRemove` ([`src/utils/effect-fs.ts`](https://github.com/floydspace/serverless-esbuild/blob/master/src/utils/effect-fs.ts)):

```ts
export const safeFileRemove = (p: string) => FS.remove(p).pipe(Effect.orElse(() => Effect.void));
```

`FS.remove` is non-recursive by default, and the directory it is handed is **never empty** — `zip()` has just copied the whole artifact into it. So the release always fails with `ENOTEMPTY`, and `Effect.orElse(() => Effect.void)` swallows the failure.

Every archive therefore leaves its staging directory behind, on every run, silently.

## Impact

With `package: { individually: true }` that is one leaked directory per function per packaging run. On a ~150-function service I measured **2.12 GB per `serverless package`**, and found **5,002 directories / 70.3 GB** accumulated on one developer machine.

It is easy to miss for two reasons: the directories live in the OS temp dir rather than in the project (so nothing in the repo grows), and the swallowed error means nothing is ever logged.

## Relationship to #586

#586 made the directory *name* unique, which correctly fixed the concurrent-build collisions in #585. It did not change the release — so the uniquely-named directories are all still left on disk. If anything the newer `${base}-${pid}-${Date.now()}-${random}` naming spreads the leak across more distinct names, which makes it harder to spot by eye.

## The fix

Adds `safeDirRemove` (recursive) and uses it for the temp directory release:

```ts
export const safeDirRemove = (p: string) => FS.remove(p, { recursive: true }).pipe(Effect.orElse(() => Effect.void));
```

`safeFileRemove` is deliberately left untouched so its semantics do not change for anything removing a plain file. If you would rather keep the surface smaller, making `safeFileRemove` itself recursive is a valid one-line alternative — it currently has no other caller — happy to switch.

## Tests

Adds a regression test to `utils/zip` covering both `useNativeZip` paths, asserting nothing matching the staging-directory name is left in `os.tmpdir()`.

Verified it fails on `master` before the fix:

```
● utils/zip › should remove its temporary staging directory when useNativeZip=false
    - Expected  - 1
    + Received  + 3
    - Array []
    + Array [
    +   "archive-17985-1785641507596-b4ae1c24",
    + ]
```

and passes after. Full suite green: **10 suites, 81 tests**. `npm run lint` clean. `npm run typecheck` shows 19 pre-existing errors under `examples/`, identical count on unmodified `master` and none in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
